### PR TITLE
TreeView iteration improvement

### DIFF
--- a/server/libFunq/player.cpp
+++ b/server/libFunq/player.cpp
@@ -176,7 +176,7 @@ void dump_items_model(QAbstractItemModel * model,
             QModelIndex index = model->index(i, j, parent);
             QtJson::JsonObject item;
             dump_item_model_attrs(model, item, index, viewid);
-            if (recursive && model->hasChildren(index)) {
+            if (j == 0 && recursive && model->hasChildren(index)) {
                 dump_items_model(model, item, index, viewid);
             }
             items << item;


### PR DESCRIPTION
Hi parkouss,

In some cases, we had problem retrieving data from a QTreeView widgets. This modification prevents Funq to iterate several times through the same children of the current row.

Cheers!