### PR TITLE
Save a GraphicsView as image.

### DIFF
--- a/client/doc/user_api/widgets_models.rst
+++ b/client/doc/user_api/widgets_models.rst
@@ -138,6 +138,8 @@ Example::
   .. automethod:: GraphicsView.gitems
 
   .. automethod:: GraphicsView.dump_gitems
+  
+  .. automethod:: GraphicsView.grab
 
 
 .. autoclass:: GItems

--- a/client/funq/models.py
+++ b/client/funq/models.py
@@ -37,7 +37,7 @@ Definition of widgets and models useable in funq.
 """
 from funq.tools import wait_for
 from funq.errors import FunqError
-import json
+import json, base64
 
 
 class TreeItem(object):  # pylint: disable=R0903
@@ -684,6 +684,24 @@ class GraphicsView(Widget):
             stream = open(stream, 'w')
         json.dump(data,
                   stream, sort_keys=True, indent=4, separators=(',', ': '))
+
+    def grab(self, stream, format_="PNG"):
+        """
+        Save the GraphicsView as image.
+        """
+        has_to_closed = False
+        data = self.client.send_command(
+            'grab_graphics_view',
+            format=format_,
+            oid=self.oid
+        )
+        if isinstance(stream, basestring):
+            stream = open(stream, 'wb')
+            has_to_closed = True
+        raw = base64.standard_b64decode(data['data'])
+        stream.write(raw) #pylint: disable=E1103
+        if has_to_closed:
+            stream.close() # pylint: disable=E1103
 
 
 class ComboBox(Widget):

--- a/server/libFunq/player.cpp
+++ b/server/libFunq/player.cpp
@@ -734,3 +734,25 @@ QtJson::JsonObject Player::widget_activate_focus(const QtJson::JsonObject & comm
     QtJson::JsonObject result;
     return result;
 }
+
+QtJson::JsonObject Player::grab_graphics_view(const QtJson::JsonObject & command) {
+    WidgetLocatorContext<QGraphicsView> ctx(this, command, "oid");
+    if (ctx.hasError()) { return ctx.lastError; }
+    QString format = command["format"].toString();
+    if (format.isEmpty()) {
+        format = "PNG";
+    }
+    QString pathFileName = command["path_filename"].toString();
+    QPixmap pixmap(ctx.widget->scene()->width(), ctx.widget->scene()->height());
+    QPainter q_painter(&pixmap);
+
+    ctx.widget->scene()->render(&q_painter);
+    QBuffer buffer;
+    pixmap.save(&buffer, "PNG");
+
+    QtJson::JsonObject result;
+    result["format"] = format;
+    result["data"] = buffer.data().toBase64();
+
+    return result;
+}

--- a/server/libFunq/player.h
+++ b/server/libFunq/player.h
@@ -97,6 +97,7 @@ public slots:
     QtJson::JsonObject headerview_list(const QtJson::JsonObject & command);
     QtJson::JsonObject headerview_click(const QtJson::JsonObject & command);
     QtJson::JsonObject headerview_path_from_view(const QtJson::JsonObject & command);
+    QtJson::JsonObject grab_graphics_view(const QtJson::JsonObject & command);
 
     QtJson::JsonObject quit(const QtJson::JsonObject & command);
 


### PR DESCRIPTION
Adding a convenient method to grab a whole GraphicsView and save it as image.