### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,10 +28,10 @@ Travis-ci build:
 
 Get funq on PyPi (server and client packages):
 
-.. image:: https://pypip.in/version/funq-server/badge.png
+.. image:: https://img.shields.io/pypi/v/funq-server.svg
     :target: https://pypi.python.org/pypi/funq-server/
 
-.. image:: https://pypip.in/version/funq/badge.png
+.. image:: https://img.shields.io/pypi/v/funq.svg
     :target: https://pypi.python.org/pypi/funq/
 
 How does *funq* works


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20funq-server))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `funq-server`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.