### PR TITLE
Enabling custom host on funq server

### DIFF
--- a/client/doc/funq.conf
+++ b/client/doc/funq.conf
@@ -10,3 +10,7 @@ funq_port = 55000
 [example_detache]
 executable = socket://localhost
 funq_port = 55001
+
+[example_detache_remote]
+executable = socket://192.168.0.2
+funq_port = 55002

--- a/client/doc/funq_conf.rst
+++ b/client/doc/funq_conf.rst
@@ -17,7 +17,9 @@ starts with "socket://" then the application will not be launched but
 the tests will try to connect to the address instead. This is the **detached**
 mode, allowing to test an already launched application (note that this
 application will have to be started with the **funq** executable, or
-compiled with libFunq).
+compiled with libFunq). Note that you can change to a valid IP address instead
+of localhost (like 192.168.0.2 as shown above) to connect in a remote
+application.
 
 Here is the list of the facultative availables options:
 

--- a/client/funq/tests/test_client.py
+++ b/client/funq/tests/test_client.py
@@ -92,6 +92,13 @@ class TestApplicationConfigFromConf:
         appconf = self.createApplicationConfig()
         assert_equals(appconf.funq_port, 12000)
 
+    def test_host(self):
+        host = '192.162.0.2'
+        self.set_opt('executable', 'toto')
+        self.set_opt('funq_host', host)
+        appconf = self.createApplicationConfig()
+        assert_equals(appconf.funq_host, host)
+
     def test_timeout_connection(self):
         self.set_opt('executable', 'toto')
         self.set_opt('timeout_connection', '5')

--- a/client/funq/tests/test_client.py
+++ b/client/funq/tests/test_client.py
@@ -92,13 +92,6 @@ class TestApplicationConfigFromConf:
         appconf = self.createApplicationConfig()
         assert_equals(appconf.funq_port, 12000)
 
-    def test_host(self):
-        host = '192.162.0.2'
-        self.set_opt('executable', 'toto')
-        self.set_opt('funq_host', host)
-        appconf = self.createApplicationConfig()
-        assert_equals(appconf.funq_host, host)
-
     def test_timeout_connection(self):
         self.set_opt('executable', 'toto')
         self.set_opt('timeout_connection', '5')

--- a/server/funq_server/runner.py
+++ b/server/funq_server/runner.py
@@ -71,6 +71,8 @@ class Runner(object):
                             version=funq_server.__version__)
         parser.add_argument('--pick', action='store_true',
                             help="Use PICK MODE, to find widget's paths")
+        parser.add_argument('--host', type=str,
+                            help="Specify funq host.")
         parser.add_argument('--port', type=int,
                             help="Specify funq port.")
         parser.add_argument('command', nargs=argparse.REMAINDER)
@@ -99,6 +101,8 @@ class Runner(object):
             env['FUNQ_MODE_PICK'] = '1'
         if opts.port is not None:
             env['FUNQ_PORT'] = str(opts.port)
+        if opts.host is not None:
+            env['FUNQ_HOST'] = str(opts.host)
 
         library_path = self._find_library()
         if not os.path.isfile(library_path):

--- a/server/libFunq/funq.h
+++ b/server/libFunq/funq.h
@@ -36,6 +36,7 @@ knowledge of the CeCILL v2.1 license and that you accept its terms.
 #define FUNQ_H
 
 #include <QObject>
+#include <QHostAddress>
 
 class QTcpServer;
 class Pick;
@@ -52,7 +53,7 @@ public:
     };
 
 protected:
-    explicit Funq(MODE mode, int port);
+    explicit Funq(MODE mode, const QHostAddress & host, int port);
     bool eventFilter(QObject* receiver, QEvent* event);
     
 signals:
@@ -71,8 +72,8 @@ private:
 
     MODE m_mode;
     int m_port;
+    QHostAddress m_host;
     QTcpServer * m_server;
-    
     Pick * m_pick;
 };
 


### PR DESCRIPTION
If you prefer a forward declaration of `QHostAddress` in funq.h, I can change the host argument on constructor to `const char*`, storing a pointer to a dynamic allocated `QHostAddress`, which will be deleted at `Funq:~Funq()`.