### PR TITLE
Fix connection issues causing the client to hang

### DIFF
--- a/client/funq/client.py
+++ b/client/funq/client.py
@@ -95,6 +95,7 @@ class FunqClient(object):
                 return e
 
         wait_for(connect, timeout_connection, 0.2)
+        self._socket.settimeout(timeout_connection)
         self._fsocket = self._socket.makefile(mode="rw")
 
     def duplicate(self):

--- a/client/funq/client.py
+++ b/client/funq/client.py
@@ -96,7 +96,7 @@ class FunqClient(object):
 
         wait_for(connect, timeout_connection, 0.2)
         self._socket.settimeout(timeout_connection)
-        self._fsocket = self._socket.makefile(mode="rw")
+        self._fsocket = self._socket.makefile(mode="rwb")
 
     def duplicate(self):
         """
@@ -129,8 +129,9 @@ class FunqClient(object):
         Send a message without waiting for an answer.
         """
         kwargs['action'] = action
-        rawdata = json.dumps(kwargs)
-        message = '%s\n%s' % (len(rawdata), rawdata)
+        rawdata = json.dumps(kwargs).encode('utf-8')
+        header = '{}\n'.format(len(rawdata)).encode('utf-8')
+        message = header + rawdata
         f = self._fsocket
         f.write(message)
         f.flush()
@@ -150,7 +151,7 @@ class FunqClient(object):
                             u"Pas de réponse de l'application testée -"
                             u" probablement un crash.")
         to_read = int(header)
-        response = json.loads(f.read(to_read))
+        response = json.loads(f.read(to_read).decode('utf-8'))
         if response.get('success') is False:
             raise FunqError(response["errName"], response["errDesc"])
         return response


### PR DESCRIPTION
### 1) Use connection timeout to avoid hanging client

Because the client had no timeout when waiting for data from the server,
it was waiting forever if too less data was received. So the client was
hanging forever. Now it aborts after a timeout has expired.

### 2) Fix wrong message length in case of multibyte characters

The client has counted the message length in characters instead of
bytes. This caused connection failures if multibyte characters were
transmitted. Now the client opens the file socket in binary mode and
manually converts messages from/to UTF-8 bytearrays. This way the
message length is always counted in bytes.