### PR TITLE
Fix Travis failing builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+cache: pip
 python:
   - "2.7"
   - "3.4"
@@ -13,10 +14,7 @@ install:
   - "cd client && python setup.py develop && cd .."
   - "cd server/tests && qmake-qt4 && make -j4 && cd ../.."
   - "cd server && python setup.py develop && cd .."
-  # use a wheel version of PySide for functiona tests
-  - pip install --find-links https://parkin.github.io/python-wheelhouse/ --use-wheel PySide;
-  # Travis CI servers use virtualenvs, so we need to finish the install by the following
-  - python ~/virtualenv/python${TRAVIS_PYTHON_VERSION}/bin/pyside_postinstall.py -install
+  - pip install PySide
 # command to run tests
 script:
   - "if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then flake8 client/funq server/funq_server; fi"

--- a/client/funq/models.py
+++ b/client/funq/models.py
@@ -102,6 +102,7 @@ class TreeItems(object):
             items = item.items + items
             yield item
 
+
 CPP_CLASSES = {}
 
 

--- a/client/funq/screenshoter.py
+++ b/client/funq/screenshoter.py
@@ -74,7 +74,7 @@ class ScreenShoter(object):  # pylint: disable=R0903
             funqclient.take_screenshot(fname, 'PNG')
         except (SystemExit, KeyboardInterrupt):
             raise
-        except:
+        except Exception:
             LOG.exception(u"impossible de prendre un screenshot pour"
                           u" %s", longname)
             return

--- a/client/funq/tests/test_client.py
+++ b/client/funq/tests/test_client.py
@@ -165,11 +165,11 @@ class TestApplicationContext:
 
     @FakePopen.patch_subprocess_popen
     def test_start(self):
-        class O:
+        class OptionsDefault:
             funq_attach_exe = 'funq'
         appconf = client.ApplicationConfig(
             executable='command',
-            global_options=O(),
+            global_options=OptionsDefault(),
         )
 
         ctx = client.ApplicationContext(
@@ -178,13 +178,13 @@ class TestApplicationContext:
 
     @FakePopen.patch_subprocess_popen
     def test_start_with_valgrind(self):
-        class P:
+        class OptionsWithValgring:
             funq_attach_exe = 'funq'
         appconf = client.ApplicationConfig(
             executable='command',
             with_valgrind=True,
             valgrind_args=[],
-            global_options=P(),
+            global_options=OptionsWithValgring(),
         )
 
         ctx = client.ApplicationContext(

--- a/client/funq/tests/test_client.py
+++ b/client/funq/tests/test_client.py
@@ -178,13 +178,13 @@ class TestApplicationContext:
 
     @FakePopen.patch_subprocess_popen
     def test_start_with_valgrind(self):
-        class O:
+        class P:
             funq_attach_exe = 'funq'
         appconf = client.ApplicationConfig(
             executable='command',
             with_valgrind=True,
             valgrind_args=[],
-            global_options=O(),
+            global_options=P(),
         )
 
         ctx = client.ApplicationContext(

--- a/server/funq_server/runner.py
+++ b/server/funq_server/runner.py
@@ -113,5 +113,6 @@ def main():
     runner = Runner()
     sys.exit(runner.run())
 
+
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Using `pip install PySide` and enable Travis cache: https://docs.travis-ci.com/user/caching/#pip-cache to reduce Pyside installing time between builds.