### PR TITLE
fix center calculation when clicking on a QuickItem

### DIFF
--- a/server/libFunq/player.cpp
+++ b/server/libFunq/player.cpp
@@ -503,9 +503,10 @@ QtJson::JsonObject Player::quick_item_click(const QtJson::JsonObject & command) 
     QuickItemLocatorContext ctx(this, command, "oid");
     if (ctx.hasError()) { return ctx.lastError; }
 
-    QPoint sPos = ctx.item->mapToScene(QPointF(0,0)).toPoint();
-    sPos.rx() += ctx.item->width() / 2;
-    sPos.ry() += ctx.item->height() / 2;
+    QPointF relativeCenter(ctx.item->width() / 2.0, ctx.item->height() / 2.0);
+
+    QPoint sPos = ctx.item->mapToScene(relativeCenter).toPoint();
+
     mouse_click(ctx.window, sPos);
     QtJson::JsonObject result;
     return result;


### PR DESCRIPTION
The previous version is correct only if the widget orientation is not
modified. A better solution is then to pass the center of the widget
as mapToScene() argument (this argument being in widget's coordinate
system) then let this method mapping the point to scene coordinate
(which is done by taking into account transformations applied to the
item).