### PR TITLE
Add support for Qt5 on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,19 @@
+os: Windows Server 2012
+build: off
+test: off
+deploy: off
+
+init:
+  - set PATH=C:/Qt/5.9/mingw53_32/bin;C:/Qt/Tools/mingw530_32/bin;%PATH%
+
+install:
+  - cp C:/Qt/Tools/mingw530_32/bin/mingw32-make.exe C:/Qt/Tools/mingw530_32/bin/make.exe
+  - cd client && python setup.py develop && cd ..
+  - cd server && python setup.py develop && cd ..
+  - cd server/tests && qmake && make -j4 && cd ../../
+  - pip install PySide
+
+build_script:
+  - cd client && python setup.py test && cd ..
+# TODO:  - make -C server/tests/ check
+# TODO:  - cd tests-functionnal && nosetests

--- a/server/funq_server/runner_win.py
+++ b/server/funq_server/runner_win.py
@@ -57,9 +57,16 @@ class WindowsRunnerInjector(RunnerInjector):
                 raise RuntimeError("Error while waiting for subprocess to be"
                                    " launched. Is the executable linked to"
                                    " qt4 ?")
-            proc.scan_modules()
+            try:
+                proc.scan_modules()
+            except WindowsError:
+                # Following exception occurs sometimes, but it still works fine
+                # so let's ignore it: WindowsError: [Error 299] Only part of a
+                # ReadProcessMemory or WriteProcessMemory request was completed
+                pass
             lib_names = [lib.get_name() for lib in proc.iter_modules()]
-            if 'qtguid4' in lib_names or 'qtgui4' in lib_names:
+            qt_lib_names = ['qtguid4', 'qtgui4', 'qt5guid', 'qt5gui']
+            if len(set(qt_lib_names).intersection(set(lib_names))) > 0:
                 break
             time.sleep(0.01)
 

--- a/server/tests/libFunq/libFunq.pro
+++ b/server/tests/libFunq/libFunq.pro
@@ -5,6 +5,8 @@ CONFIG += testcase qtestlib
 
 INCLUDEPATH += ../../libFunq
 
+DEFINES += SOURCE_DIR=\\\"$${PWD}/\\\"
+
 SOURCES = test.cpp
 
 SOURCES += ../../libFunq/objectpath.cpp ../../libFunq/player.cpp ../../libFunq/dragndropresponse.cpp ../../libFunq/shortcutresponse.cpp

--- a/server/tests/libFunq/test.cpp
+++ b/server/tests/libFunq/test.cpp
@@ -783,11 +783,8 @@ private slots:
     /* QtQuick tests */
 
     void test_quick_item_by_path() {
-        QString qml_path = QDir(qApp->applicationDirPath()).filePath("sample1.qml");
         QQuickView view;
-
-        view.setSource(QUrl::fromLocalFile(qml_path));
-
+        view.setSource(QUrl::fromLocalFile(SOURCE_DIR "sample1.qml"));
         view.show();
         QTest::qWaitForWindowExposed(&view);
 
@@ -818,11 +815,8 @@ private slots:
     }
 
     void test_quick_item_find_by_id() {
-        QString qml_path = QDir(qApp->applicationDirPath()).filePath("find_by_id.qml");
         QQuickView view;
-
-        view.setSource(QUrl::fromLocalFile(qml_path));
-
+        view.setSource(QUrl::fromLocalFile(SOURCE_DIR "find_by_id.qml"));
         view.show();
         QTest::qWaitForWindowExposed(&view);
 
@@ -876,11 +870,8 @@ private slots:
     }
 
     void test_quick_item_click() {
-        QString qml_path = QDir(qApp->applicationDirPath()).filePath("test_click.qml");
         QQuickView view;
-
-        view.setSource(QUrl::fromLocalFile(qml_path));
-
+        view.setSource(QUrl::fromLocalFile(SOURCE_DIR "test_click.qml"));
         view.show();
         QTest::qWaitForWindowExposed(&view);
 


### PR DESCRIPTION
With these changes I was able to use funq with my Qt5 application on Windows (with Python 2.7). I also added `appveyor.yml` to use CI on Windows (it would be great if you enable [AppVeyor](https://www.appveyor.com/) on this repository).

Unfortunately some tests are not (yet) working on Windows, so they are disabled for now. Here the output of libFunqTest:

```
********* Start testing of LibFunqTest *********
Config: Using QtTest library 5.9.5, Qt 5.9.5 (i386-little_endian-ilp32 shared (dynamic) release build; by GCC 5.3.0)
PASS   : LibFunqTest::initTestCase()
PASS   : LibFunqTest::test_objectPath_objectName_noname()
PASS   : LibFunqTest::test_objectPath_objectName_named()
PASS   : LibFunqTest::test_objectPath_objectName_noname_with_siblings()
PASS   : LibFunqTest::test_objectPath_objectName_named_with_siblings()
PASS   : LibFunqTest::test_objectPath_objectName_named_same_with_siblings()
PASS   : LibFunqTest::test_objectPath_objectPath_simple()
PASS   : LibFunqTest::test_objectPath_objectPath_simple_with_sep()
PASS   : LibFunqTest::test_objectPath_findObject_simple()
PASS   : LibFunqTest::test_objectPath_findObject_with_sep()
PASS   : LibFunqTest::test_objectpath_graphicsItemId()
PASS   : LibFunqTest::test_objectpath_graphicsItemFromId()
PASS   : LibFunqTest::test_player_widget_by_path()
PASS   : LibFunqTest::test_player_widget_by_path_wrong_path()
PASS   : LibFunqTest::test_player_object_properties()
PASS   : LibFunqTest::test_player_not_registered_object()
PASS   : LibFunqTest::test_player_deleted_object()
PASS   : LibFunqTest::test_player_active_widget()
PASS   : LibFunqTest::test_player_object_set_properties()
PASS   : LibFunqTest::test_player_widgets_list()
PASS   : LibFunqTest::test_player_widgets_list_with_oid()
PASS   : LibFunqTest::test_player_widget_click()
PASS   : LibFunqTest::test_player_widget_close()
PASS   : LibFunqTest::test_player_call_slot()
PASS   : LibFunqTest::test_player_widget_keyclick()
QWARN  : LibFunqTest::test_player_shortcut() QIODevice::write (QBuffer): device not open
FAIL!  : LibFunqTest::test_player_shortcut() Compared values are not the same
   Actual   (spy.count()): 0
   Expected (1)          : 1
test.cpp(536) : failure location
QWARN  : LibFunqTest::test_player_shortcut_15_times() QIODevice::write (QBuffer): device not open
FAIL!  : LibFunqTest::test_player_shortcut_15_times() Compared values are not the same
   Actual   (spy.count()): 0
   Expected (1)          : 1
test.cpp(536) : failure location
QWARN  : LibFunqTest::test_player_shortcut_15_times() QIODevice::write (QBuffer): device not open
FAIL!  : LibFunqTest::test_player_shortcut_15_times() Compared values are not the same
   Actual   (spy.count()): 0
   Expected (1)          : 1
test.cpp(536) : failure location
QWARN  : LibFunqTest::test_player_shortcut_15_times() QIODevice::write (QBuffer): device not open
FAIL!  : LibFunqTest::test_player_shortcut_15_times() Compared values are not the same
   Actual   (spy.count()): 0
   Expected (1)          : 1
test.cpp(536) : failure location
QWARN  : LibFunqTest::test_player_shortcut_15_times() QIODevice::write (QBuffer): device not open
FAIL!  : LibFunqTest::test_player_shortcut_15_times() Compared values are not the same
   Actual   (spy.count()): 0
   Expected (1)          : 1
test.cpp(536) : failure location
QWARN  : LibFunqTest::test_player_shortcut_15_times() QIODevice::write (QBuffer): device not open
FAIL!  : LibFunqTest::test_player_shortcut_15_times() Compared values are not the same
   Actual   (spy.count()): 0
   Expected (1)          : 1
test.cpp(536) : failure location
QWARN  : LibFunqTest::test_player_shortcut_15_times() QIODevice::write (QBuffer): device not open
FAIL!  : LibFunqTest::test_player_shortcut_15_times() Compared values are not the same
   Actual   (spy.count()): 0
   Expected (1)          : 1
test.cpp(536) : failure location
QWARN  : LibFunqTest::test_player_shortcut_15_times() QIODevice::write (QBuffer): device not open
FAIL!  : LibFunqTest::test_player_shortcut_15_times() Compared values are not the same
   Actual   (spy.count()): 0
   Expected (1)          : 1
test.cpp(536) : failure location
QWARN  : LibFunqTest::test_player_shortcut_15_times() QIODevice::write (QBuffer): device not open
FAIL!  : LibFunqTest::test_player_shortcut_15_times() Compared values are not the same
   Actual   (spy.count()): 0
   Expected (1)          : 1
test.cpp(536) : failure location
QWARN  : LibFunqTest::test_player_shortcut_15_times() QIODevice::write (QBuffer): device not open
FAIL!  : LibFunqTest::test_player_shortcut_15_times() Compared values are not the same
   Actual   (spy.count()): 0
   Expected (1)          : 1
test.cpp(536) : failure location
QWARN  : LibFunqTest::test_player_shortcut_15_times() QIODevice::write (QBuffer): device not open
FAIL!  : LibFunqTest::test_player_shortcut_15_times() Compared values are not the same
   Actual   (spy.count()): 0
   Expected (1)          : 1
test.cpp(536) : failure location
QWARN  : LibFunqTest::test_player_shortcut_15_times() QIODevice::write (QBuffer): device not open
FAIL!  : LibFunqTest::test_player_shortcut_15_times() Compared values are not the same
   Actual   (spy.count()): 0
   Expected (1)          : 1
test.cpp(536) : failure location
QWARN  : LibFunqTest::test_player_shortcut_15_times() QIODevice::write (QBuffer): device not open
FAIL!  : LibFunqTest::test_player_shortcut_15_times() Compared values are not the same
   Actual   (spy.count()): 0
   Expected (1)          : 1
test.cpp(536) : failure location
QWARN  : LibFunqTest::test_player_shortcut_15_times() QIODevice::write (QBuffer): device not open
FAIL!  : LibFunqTest::test_player_shortcut_15_times() Compared values are not the same
   Actual   (spy.count()): 0
   Expected (1)          : 1
test.cpp(536) : failure location
QWARN  : LibFunqTest::test_player_shortcut_15_times() QIODevice::write (QBuffer): device not open
FAIL!  : LibFunqTest::test_player_shortcut_15_times() Compared values are not the same
   Actual   (spy.count()): 0
   Expected (1)          : 1
test.cpp(536) : failure location
QWARN  : LibFunqTest::test_player_shortcut_15_times() QIODevice::write (QBuffer): device not open
FAIL!  : LibFunqTest::test_player_shortcut_15_times() Compared values are not the same
   Actual   (spy.count()): 0
   Expected (1)          : 1
test.cpp(536) : failure location
PASS   : LibFunqTest::test_player_tabbar_list()
PASS   : LibFunqTest::test_player_headerview_list()
PASS   : LibFunqTest::test_player_headerview_click()
PASS   : LibFunqTest::test_player_headerview_click_by_name()
PASS   : LibFunqTest::test_player_model_items()
��(PASS   : LibFunqTest::test_quick_item_by_path()
PASS   : LibFunqTest::test_quick_item_find_by_id()
PASS   : LibFunqTest::test_quick_item_click()
PASS   : LibFunqTest::cleanupTestCase()
Totals: 34 passed, 16 failed, 0 skipped, 0 blacklisted, 14941ms
********* Finished testing of LibFunqTest *********
```

The functional tests (with nose) are failing too, and I have no idea why...