### PR TITLE
Support drag'n'drop on QuickItem elements

### DIFF
--- a/client/funq/models.py
+++ b/client/funq/models.py
@@ -794,6 +794,22 @@ class QuickItem(Object):
             oid=self.oid
         )
 
+    def drag_n_drop(self, src_pos=None,
+                    dest_widget=None, dest_pos=None):
+        """
+        Do a drag and drop from this widget.
+
+        :param src_pos: starting position of the drag. Must be a tuple (x, y)
+                        in widget coordinates or None (the center of the widget
+                        will then be used)
+        :param dest_widget: destination widget. If None, src_widget will be
+                            used.
+        :param dest_pos: ending position (the drop). Must be a tuple (x, y)
+                         in widget coordinates or None (the center of the dest
+                         widget will then be used)
+        """
+        self.client.drag_n_drop(self, src_pos=src_pos, dest_widget=dest_widget,
+                                dest_pos=dest_pos)
 
 class QuickWindow(Widget):
     """

--- a/server/libFunq/dragndrophelpers.cpp
+++ b/server/libFunq/dragndrophelpers.cpp
@@ -1,0 +1,68 @@
+/*
+Copyright: SCLE SFE
+Contributor: Julien Pagès <j.parkouss@gmail.com>
+
+This software is a computer program whose purpose is to test graphical
+applications written with the QT framework (http://qt.digia.com/).
+
+This software is governed by the CeCILL v2.1 license under French law and
+abiding by the rules of distribution of free software.  You can  use,
+modify and/ or redistribute the software under the terms of the CeCILL
+license as circulated by CEA, CNRS and INRIA at the following URL
+"http://www.cecill.info".
+
+As a counterpart to the access to the source code and  rights to copy,
+modify and redistribute granted by the license, users are provided only
+with a limited warranty  and the software's author,  the holder of the
+economic rights,  and the successive licensors  have only  limited
+liability.
+
+In this respect, the user's attention is drawn to the risks associated
+with loading,  using,  modifying and/or developing or reproducing the
+software by the user in light of its specific status of free software,
+that may mean  that it is complicated to manipulate,  and  that  also
+therefore means  that it is reserved for developers  and  experienced
+professionals having in-depth computer knowledge. Users are therefore
+encouraged to load and test the software's suitability as regards their
+requirements in conditions enabling the security of their systems and/or
+data to be ensured and,  more generally, to use and operate it in the
+same conditions as regards security.
+
+The fact that you are presently reading this means that you have had
+knowledge of the CeCILL v2.1 license and that you accept its terms.
+*/
+
+#include "dragndrophelpers.h"
+#include <QPoint>
+#include <QList>
+#include <QString>
+
+void calculate_drag_n_drop_moves(QList<QPoint> & moves,
+                                 const QPoint & globalSourcePos,
+                                 const QPoint & globalDestPos,
+                                 int deltaFactor) {
+    QPoint delta = globalDestPos - globalSourcePos;
+    delta /= deltaFactor;
+
+    QPoint move = globalSourcePos;
+    QPoint lastMove = globalSourcePos;
+    for (int i = 0; i < deltaFactor; ++i) {
+        move += delta;
+        if (move != lastMove) {
+            lastMove = move;
+            moves << move;
+        }
+    }
+    moves << globalDestPos;
+}
+
+QPoint pointFromString(const QString & data) {
+    QStringList splitted = data.split(",");
+    if (splitted.count() == 2) {
+        QPoint p;
+        p.setX(splitted[0].toInt());
+        p.setY(splitted[1].toInt());
+        return p;
+    }
+    return QPoint();
+}

--- a/server/libFunq/dragndrophelpers.h
+++ b/server/libFunq/dragndrophelpers.h
@@ -1,0 +1,50 @@
+/*
+Copyright: SCLE SFE
+Contributor: Julien Pagès <j.parkouss@gmail.com>
+
+This software is a computer program whose purpose is to test graphical
+applications written with the QT framework (http://qt.digia.com/).
+
+This software is governed by the CeCILL v2.1 license under French law and
+abiding by the rules of distribution of free software.  You can  use,
+modify and/ or redistribute the software under the terms of the CeCILL
+license as circulated by CEA, CNRS and INRIA at the following URL
+"http://www.cecill.info".
+
+As a counterpart to the access to the source code and  rights to copy,
+modify and redistribute granted by the license, users are provided only
+with a limited warranty  and the software's author,  the holder of the
+economic rights,  and the successive licensors  have only  limited
+liability.
+
+In this respect, the user's attention is drawn to the risks associated
+with loading,  using,  modifying and/or developing or reproducing the
+software by the user in light of its specific status of free software,
+that may mean  that it is complicated to manipulate,  and  that  also
+therefore means  that it is reserved for developers  and  experienced
+professionals having in-depth computer knowledge. Users are therefore
+encouraged to load and test the software's suitability as regards their
+requirements in conditions enabling the security of their systems and/or
+data to be ensured and,  more generally, to use and operate it in the
+same conditions as regards security.
+
+The fact that you are presently reading this means that you have had
+knowledge of the CeCILL v2.1 license and that you accept its terms.
+*/
+
+#ifndef DRAGNDROPHELPERS_H
+#define DRAGNDROPHERLPER_H
+
+#include <QList>
+
+class QPoint;
+class QString;
+
+void calculate_drag_n_drop_moves(QList<QPoint> & moves,
+                                 const QPoint & globalSourcePos,
+                                 const QPoint & globalDestPos,
+                                 int deltaFactor=4);
+
+QPoint pointFromString(const QString & data);
+
+#endif // DRAGNDROPHELPERS_H

--- a/server/libFunq/dragndropresponse.cpp
+++ b/server/libFunq/dragndropresponse.cpp
@@ -33,40 +33,11 @@ knowledge of the CeCILL v2.1 license and that you accept its terms.
 */
 
 #include "dragndropresponse.h"
+#include "dragndrophelpers.h"
 #include <QApplication>
 #include <QMouseEvent>
 #include <QTimer>
 #include "player.h"
-
-void calculate_drag_n_drop_moves(QList<QPoint> & moves,
-                                 const QPoint & globalSourcePos,
-                                 const QPoint & globalDestPos,
-                                 int deltaFactor=4) {
-    QPoint delta = globalDestPos - globalSourcePos;
-    delta /= deltaFactor;
-
-    QPoint move = globalSourcePos;
-    QPoint lastMove = globalSourcePos;
-    for (int i = 0; i < deltaFactor; ++i) {
-        move += delta;
-        if (move != lastMove) {
-            lastMove = move;
-            moves << move;
-        }
-    }
-    moves << globalDestPos;
-}
-
-QPoint pointFromString(const QString & data) {
-    QStringList splitted = data.split(",");
-    if (splitted.count() == 2) {
-        QPoint p;
-        p.setX(splitted[0].toInt());
-        p.setY(splitted[1].toInt());
-        return p;
-    }
-    return QPoint();
-}
 
 DragNDropResponse::DragNDropResponse(JsonClient *client, const QtJson::JsonObject &command) :
     DelayedResponse(client, command)

--- a/server/libFunq/libFunq.pri
+++ b/server/libFunq/libFunq.pri
@@ -7,6 +7,7 @@ INCLUDEPATH += $${PWD}
 SOURCES += $${PWD}/player.cpp \
     $${PWD}/funq.cpp \
     $${PWD}/objectpath.cpp \
+    $${PWD}/dragndrophelpers.cpp \
     $${PWD}/dragndropresponse.cpp \
     $${PWD}/shortcutresponse.cpp \
     $${PWD}/pick.cpp

--- a/server/libFunq/libFunq.pri
+++ b/server/libFunq/libFunq.pri
@@ -9,6 +9,7 @@ SOURCES += $${PWD}/player.cpp \
     $${PWD}/objectpath.cpp \
     $${PWD}/dragndrophelpers.cpp \
     $${PWD}/dragndropresponse.cpp \
+    $${PWD}/quickdragndropresponse.cpp \
     $${PWD}/shortcutresponse.cpp \
     $${PWD}/pick.cpp
 
@@ -16,6 +17,7 @@ HEADERS += $${PWD}/player.h \
     $${PWD}/funq.h \
     $${PWD}/objectpath.h \
     $${PWD}/dragndropresponse.h \
+    $${PWD}/quickdragndropresponse.h \
     $${PWD}/shortcutresponse.h \
     $${PWD}/pick.h
 

--- a/server/libFunq/player.cpp
+++ b/server/libFunq/player.cpp
@@ -51,6 +51,7 @@ knowledge of the CeCILL v2.1 license and that you accept its terms.
 #include <QTime>
 #include <QHeaderView>
 #include "dragndropresponse.h"
+#include "quickdragndropresponse.h"
 #include "shortcutresponse.h"
 
 #ifdef QT_QUICK_LIB
@@ -809,7 +810,13 @@ QtJson::JsonObject Player::gitem_properties(const QtJson::JsonObject & command) 
 }
 
 DelayedResponse * Player::drag_n_drop(const QtJson::JsonObject & command) {
-    return new DragNDropResponse(this, command);
+    auto id = command["srcoid"].value<qulonglong>();
+    auto* obj = registeredObject(id);
+    auto* item = qobject_cast<QQuickItem *>(obj);
+    if (item)
+        return new QuickDragNDropResponse(this, command);
+    else
+        return new DragNDropResponse(this, command);
 }
 
 QtJson::JsonObject Player::call_slot(const QtJson::JsonObject & command) {

--- a/server/libFunq/quickdragndropresponse.cpp
+++ b/server/libFunq/quickdragndropresponse.cpp
@@ -1,0 +1,112 @@
+/*
+Copyright: SCLE SFE
+Contributor: Julien Pagès <j.parkouss@gmail.com>
+Contributor: Anthony Léonard <anthony.leonard@savoirfairelinux.com>
+
+This software is a computer program whose purpose is to test graphical
+applications written with the QT framework (http://qt.digia.com/).
+
+This software is governed by the CeCILL v2.1 license under French law and
+abiding by the rules of distribution of free software.  You can  use,
+modify and/ or redistribute the software under the terms of the CeCILL
+license as circulated by CEA, CNRS and INRIA at the following URL
+"http://www.cecill.info".
+
+As a counterpart to the access to the source code and  rights to copy,
+modify and redistribute granted by the license, users are provided only
+with a limited warranty  and the software's author,  the holder of the
+economic rights,  and the successive licensors  have only  limited
+liability.
+
+In this respect, the user's attention is drawn to the risks associated
+with loading,  using,  modifying and/or developing or reproducing the
+software by the user in light of its specific status of free software,
+that may mean  that it is complicated to manipulate,  and  that  also
+therefore means  that it is reserved for developers  and  experienced
+professionals having in-depth computer knowledge. Users are therefore
+encouraged to load and test the software's suitability as regards their
+requirements in conditions enabling the security of their systems and/or
+data to be ensured and,  more generally, to use and operate it in the
+same conditions as regards security.
+
+The fact that you are presently reading this means that you have had
+knowledge of the CeCILL v2.1 license and that you accept its terms.
+*/
+
+#include "quickdragndropresponse.h"
+#include "dragndrophelpers.h"
+#include <QApplication>
+#include <QMouseEvent>
+#include <QTimer>
+#include "player.h"
+
+QuickDragNDropResponse::QuickDragNDropResponse(JsonClient *client, const QtJson::JsonObject &command) :
+    DelayedResponse(client, command)
+{
+    QuickItemLocatorContext ctx(static_cast<Player *>(jsonClient()), command, "srcoid");
+    QuickItemLocatorContext ctx2(static_cast<Player *>(jsonClient()), command, "destoid");
+
+    if (ctx.hasError()) { writeResponse(ctx.lastError); return; }
+    if (ctx2.hasError()) { writeResponse(ctx2.lastError); return; }
+
+    QPoint srcPos;
+    if (command.contains("srcpos") && ! command["srcpos"].isNull()) {
+        srcPos = pointFromString(command["srcpos"].toString());
+    } else {
+        srcPos = QPoint(ctx.item->width() / 2.0, ctx.item->height() / 2.0);
+    }
+
+    QPoint destPos;
+    if (command.contains("destpos") && ! command["destpos"].isNull()) {
+        destPos = pointFromString(command["destpos"].toString());
+    } else {
+        destPos = QPoint(ctx2.item->width() / 2.0, ctx2.item->height() / 2.0);
+    }
+
+    m_window = ctx.window;
+    m_srcPosGlobal = ctx.item->mapToGlobal(srcPos).toPoint();
+    m_destPosGlobal = ctx2.item->mapToGlobal(destPos).toPoint();
+    calculate_drag_n_drop_moves(m_moves, m_srcPosGlobal, m_destPosGlobal, 8);
+}
+
+void QuickDragNDropResponse::execute(int call) {
+    switch (call) {
+    case 0: // 0: press event
+        qApp->postEvent(m_window,
+            new QMouseEvent(QEvent::MouseButtonPress,
+                            m_window->mapFromGlobal(m_srcPosGlobal),
+                            m_srcPosGlobal,
+                            Qt::LeftButton,
+                            Qt::NoButton,
+                            Qt::NoModifier));
+        setInterval(20);
+        break;
+    case 1: { // 1: do some move event
+        if (m_moves.isEmpty())
+            break;
+
+        const QPoint move = m_moves.takeFirst();
+        qApp->postEvent(m_window,
+            new QMouseEvent(QEvent::MouseMove,
+                            m_window->mapFromGlobal(move),
+                            move,
+                            Qt::LeftButton,
+                            Qt::NoButton,
+                            Qt::NoModifier));
+        m_nbCall -= 1;
+        break;
+    }
+    case 2: { // 2: now release the button
+        qApp->postEvent(m_window,
+            new QMouseEvent(QEvent::MouseButtonRelease,
+                            m_window->mapFromGlobal(m_destPosGlobal),
+                            m_destPosGlobal,
+                            Qt::LeftButton,
+                            Qt::NoButton,
+                            Qt::NoModifier));
+    }
+    case 3: // and reply
+        writeResponse(QtJson::JsonObject());
+        break;
+    }
+}

--- a/server/libFunq/quickdragndropresponse.h
+++ b/server/libFunq/quickdragndropresponse.h
@@ -1,0 +1,62 @@
+/*
+Copyright: SCLE SFE
+Contributor: Julien Pagès <j.parkouss@gmail.com>
+Contributor: Anthony Léonard <anthony.leonard@savoirfairelinux.com>
+
+This software is a computer program whose purpose is to test graphical
+applications written with the QT framework (http://qt.digia.com/).
+
+This software is governed by the CeCILL v2.1 license under French law and
+abiding by the rules of distribution of free software.  You can  use,
+modify and/ or redistribute the software under the terms of the CeCILL
+license as circulated by CEA, CNRS and INRIA at the following URL
+"http://www.cecill.info".
+
+As a counterpart to the access to the source code and  rights to copy,
+modify and redistribute granted by the license, users are provided only
+with a limited warranty  and the software's author,  the holder of the
+economic rights,  and the successive licensors  have only  limited
+liability.
+
+In this respect, the user's attention is drawn to the risks associated
+with loading,  using,  modifying and/or developing or reproducing the
+software by the user in light of its specific status of free software,
+that may mean  that it is complicated to manipulate,  and  that  also
+therefore means  that it is reserved for developers  and  experienced
+professionals having in-depth computer knowledge. Users are therefore
+encouraged to load and test the software's suitability as regards their
+requirements in conditions enabling the security of their systems and/or
+data to be ensured and,  more generally, to use and operate it in the
+same conditions as regards security.
+
+The fact that you are presently reading this means that you have had
+knowledge of the CeCILL v2.1 license and that you accept its terms.
+*/
+
+#ifndef QUICKDRAGNDROPRESPONSE_H
+#define QUICKDRAGNDROPRESPONSE_H
+
+#include "delayedresponse.h"
+#include <QQuickItem>
+#include <QQuickWindow>
+
+class QuickDragNDropResponse : public DelayedResponse
+{
+public:
+    explicit QuickDragNDropResponse(JsonClient * client, const QtJson::JsonObject & command);
+
+protected:
+    virtual void execute(int call);
+
+signals:
+
+public slots:
+
+private:
+    QQuickWindow * m_window;
+    QPoint m_srcPosGlobal;
+    QPoint m_destPosGlobal;
+    QList<QPoint> m_moves;
+};
+
+#endif // QUICKDRAGNDROPRESPONSE_H

--- a/server/protocole/delayedresponse.h
+++ b/server/protocole/delayedresponse.h
@@ -101,6 +101,8 @@ private:
     QTimer m_timer;
     QString m_action;
     bool m_hasResponded;
+
+protected:
     int m_nbCall;
 };
 


### PR DESCRIPTION
This add a way to send drag'n'drop to an application based on QuickView and QML.

Also, move events are sent at a reduced pace compared to initial implementation (which sends them all at once). This gives a more realistic input and better compatibility with some widgets that are not reacting very well with a drag done too fast (like SwipeView).

It is a first implementation based on the already present one which could be refined to reduce code duplication between both of them.