### PR TITLE
README.rst: Update notes about Windows support and add AppVeyor badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ How does *funq* works
   executable called **funq** and a dynamic library **libFunq**. The
   **funq** executable allows to inject some code in a Qt application
   to start a TCP server that will allow to interact with the application.
-  This is currently not working well on windows, but you can still
+  This is currently not working with Python 3 on Windows, but you can still
   build you application with libFunq as a workaround.
 
 - **funq** is a python package that offers an API to interact with a
@@ -56,9 +56,10 @@ Known restrictions
 Funq currently works with python >= 2.7 (it is fully compatible with python 3),
 Qt4 and Qt5 on GNU/Linux.
 
-It also works on Windows, but the tested application have to be compiled
-with libFunq (I am not able to do a fully working dll injection for this
-platform, windows expert you're welcome!).
+It also works on Windows, but only with Python 2.7 out of the box. With
+Python 3, the tested application has to be compiled with libFunq because the
+package *winappdbg* (needed for the DLL injection) is not available for Python 3
+(any help welcome!).
 
 Installation
 ============

--- a/README.rst
+++ b/README.rst
@@ -21,10 +21,13 @@ Tutorial and documentation:
 .. image:: https://readthedocs.org/projects/funq/badge/?version=latest
     :target: http://funq.readthedocs.org
 
-Travis-ci build:
+CI build status:
 
 .. image:: https://travis-ci.org/parkouss/funq.svg?branch=master
     :target: https://travis-ci.org/parkouss/funq
+
+.. image:: https://ci.appveyor.com/api/projects/status/github/parkouss/funq?branch=master&svg=true
+    :target: https://ci.appveyor.com/project/parkouss/funq
 
 Get funq on PyPi (server and client packages):
 


### PR DESCRIPTION
As `funq` now also works on Windows (at least better than before #32), the readme should be updated accordingly.

Also adds the AppVeyor build status badge (see https://github.com/parkouss/funq/issues/10#issuecomment-422462409).

Please let me know if I should change something :)