### PR TITLE
Travis-CI: Add jobs for Qt5 and MacOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,65 @@
-language: python
-cache: pip
-python:
-  - "2.7"
-  - "3.4"
-before_install:
-  - "sudo apt-get update -qq"
-  - "sudo apt-get install -qq libqt4-dev qt4-dev-tools"
-  - "sudo apt-get install -qq xvfb"
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
+sudo: required
+cache:
+  - pip
+  - ccache
+notifications:
+  email:
+    on_success: change
+    on_failure: change
+
+matrix:
+  fast_finish: true
+  include:
+
+    # Linux Qt4 Python2.7
+    - os: linux
+      dist: trusty
+      language: python
+      python: 2.7
+      env: QT_SELECT=4 PYTHON=python
+
+    # Linux Qt4 Python3.4
+    - os: linux
+      dist: trusty
+      language: python
+      python: 3.4
+      env: QT_SELECT=4 PYTHON=python
+
+    # Linux Qt5 Python2.7
+    - os: linux
+      dist: trusty
+      language: python
+      python: 2.7
+      env: QT_SELECT=5 PYTHON=python
+
+    # Linux Qt5 Python3.4
+    - os: linux
+      dist: trusty
+      language: python
+      python: 3.4
+      env: QT_SELECT=5 PYTHON=python
+
+    # MacOS Qt5 Python2
+    - os: osx
+      language: cpp
+      env: QT_SELECT=5 PYTHON=python2
+
+    # MacOS Qt5 Python3
+    - os: osx
+      language: cpp
+      env: QT_SELECT=5 PYTHON=python3
+
 install:
-  - "if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then pip install flake8; fi"
-  - "cd client && python setup.py develop && cd .."
-  - "cd server/tests && qmake-qt4 && make -j4 && cd ../.."
-  - "cd server && python setup.py develop && cd .."
-  - pip install PySide
-# command to run tests
+  - source ./ci/install_dependencies.sh # source required because of exports
+  - $PYTHON --version                   # check exact python version
+  - qmake --version                     # check exact Qt version
+
 script:
-  - "if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then flake8 client/funq server/funq_server; fi"
-  - "cd client && python setup.py test; cd .."
-  - "make -C server/tests/ check"
-  - "cd tests-functionnal && nosetests && cd .."
+  - flake8 client/funq server/funq_server
+  - cd client && $PYTHON setup.py develop && cd ..
+  - cd server && $PYTHON setup.py develop && cd ..
+  - cd server/tests && qmake && make -j4 && cd ../..
+  - cd client && $PYTHON setup.py test; cd ..
+  - make -C server/tests/ check
+  # PySide is Qt4, so we can't run functional tests with Qt5!
+  - if [[ "$QT_SELECT" == "4" ]]; then cd tests-functionnal && nosetests && cd .. ; fi

--- a/ci/install_dependencies.sh
+++ b/ci/install_dependencies.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# use multiple cores for building
+export MAKEFLAGS="-j8"
+
+# Install dependencies on Linux
+if [[ "${TRAVIS_OS_NAME-}" == "linux" ]]
+then
+
+  # common
+  sudo apt-get update -qq
+  sudo apt-get install -qq build-essential xvfb
+
+  # qt
+  if [[ "$QT_SELECT" == "4" ]]
+  then
+    sudo apt-get install -qq libqt4-dev qt4-dev-tools
+  elif [[ "$QT_SELECT" == "5" ]]
+  then
+    sudo apt-get install -qq qtbase5-dev qtdeclarative5-dev qtdeclarative5-qtquick2-plugin qttools5-dev-tools
+  fi
+
+  # python packages
+  pip install flake8 PySide
+
+  # xvfb
+  export DISPLAY=:99.0
+  sh -e /etc/init.d/xvfb start
+
+
+# Install dependencies on OS X
+elif [[ "${TRAVIS_OS_NAME-}" == "osx" ]]
+then
+
+  # ccache
+  brew update
+  brew install ccache
+  export PATH="/usr/local/opt/ccache/libexec:$PATH"
+
+  # qt
+  brew install qt5
+  brew link --force qt5
+
+  # python packages
+  pip${PYTHON/python/} install --user flake8
+  export PATH="$PATH:`$PYTHON -m site --user-base`/bin"
+
+fi

--- a/client/funq/aliases.py
+++ b/client/funq/aliases.py
@@ -67,7 +67,7 @@ class HooqAliases(dict):
         try:
             # pylint: disable=W0142
             value = value.format(**self)
-        except KeyError, msg:
+        except KeyError as msg:
             raise HooqAliasesKeyError("Impossible substitution in"
                                       " the alias %s: %s." % (name, msg))
         dict.__setitem__(self, name, value)

--- a/client/funq/client.py
+++ b/client/funq/client.py
@@ -55,6 +55,14 @@ from funq.errors import FunqError, TimeOutError
 LOG = logging.getLogger('funq.client')
 
 
+# python 3 compatibility
+# https://stackoverflow.com/questions/11301138/how-to-check-if-variable-is-string-with-python-2-and-3-compatibility)
+try:
+    basestring
+except NameError:
+    basestring = str
+
+
 class FunqClient(object):
 
     """
@@ -89,7 +97,7 @@ class FunqClient(object):
             try:
                 self._socket.connect((host, port))
                 return True
-            except socket.error, e:
+            except socket.error as e:
                 if e.errno != errno.ECONNREFUSED:
                     raise
                 return e
@@ -194,7 +202,7 @@ class FunqClient(object):
             try:
                 wdata[0] = self.send_command('widget_by_path', path=path)
                 return True
-            except FunqError, err:
+            except FunqError as err:
                 if err.classname != 'InvalidWidgetPath':
                     raise
                 return err
@@ -244,7 +252,7 @@ class FunqClient(object):
             try:
                 wdata[0] = self.send_command('active_widget', type=widget_type)
                 return True
-            except FunqError, err:
+            except FunqError as err:
                 if err.classname != 'NoActiveWindow':
                     raise
                 return err

--- a/client/funq/models.py
+++ b/client/funq/models.py
@@ -41,6 +41,14 @@ import json
 import base64
 
 
+# python 3 compatibility
+# https://stackoverflow.com/questions/11301138/how-to-check-if-variable-is-string-with-python-2-and-3-compatibility)
+try:
+    basestring
+except NameError:
+    basestring = str
+
+
 class TreeItem(object):  # pylint: disable=R0903
 
     """

--- a/client/funq/testcase.py
+++ b/client/funq/testcase.py
@@ -45,6 +45,14 @@ import re
 import inspect
 
 
+# python 3 compatibility
+# https://stackoverflow.com/questions/11301138/how-to-check-if-variable-is-string-with-python-2-and-3-compatibility)
+try:
+    unicode
+except NameError:
+    unicode = str
+
+
 class AssertionSuccessError(AssertionError):
 
     """

--- a/server/funq_server/runner.py
+++ b/server/funq_server/runner.py
@@ -82,6 +82,8 @@ class Runner(object):
         this_dir = os.path.dirname(os.path.realpath(__file__))
         if self.system == 'Windows':
             library_name = 'Funq.dll'
+        elif self.system == 'Darwin':
+            library_name = 'libFunq.dylib'
         else:
             library_name = 'libFunq.so'
         return os.path.join(this_dir, library_name)
@@ -89,6 +91,8 @@ class Runner(object):
     def _create_injector_class(self):
         if self.system == 'Windows':
             from funq_server.runner_win import WindowsRunnerInjector as RI
+        elif self.system == 'Darwin':
+            from funq_server.runner_mac import MacRunnerInjector as RI
         else:
             from funq_server.runner_linux import LinuxRunnerInjector as RI
         return RI

--- a/server/funq_server/runner_mac.py
+++ b/server/funq_server/runner_mac.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: SCLE SFE
+# Contributor: Julien Pagès <j.parkouss@gmail.com>
+#
+# This software is a computer program whose purpose is to test graphical
+# applications written with the QT framework (http://qt.digia.com/).
+#
+# This software is governed by the CeCILL v2.1 license under French law and
+# abiding by the rules of distribution of free software.  You can  use,
+# modify and/ or redistribute the software under the terms of the CeCILL
+# license as circulated by CEA, CNRS and INRIA at the following URL
+# "http://www.cecill.info".
+#
+# As a counterpart to the access to the source code and  rights to copy,
+# modify and redistribute granted by the license, users are provided only
+# with a limited warranty  and the software's author,  the holder of the
+# economic rights,  and the successive licensors  have only  limited
+# liability.
+#
+# In this respect, the user's attention is drawn to the risks associated
+# with loading,  using,  modifying and/or developing or reproducing the
+# software by the user in light of its specific status of free software,
+# that may mean  that it is complicated to manipulate,  and  that  also
+# therefore means  that it is reserved for developers  and  experienced
+# professionals having in-depth computer knowledge. Users are therefore
+# encouraged to load and test the software's suitability as regards their
+# requirements in conditions enabling the security of their systems and/or
+# data to be ensured and,  more generally, to use and operate it in the
+# same conditions as regards security.
+#
+# The fact that you are presently reading this means that you have had
+# knowledge of the CeCILL v2.1 license and that you accept its terms.
+
+from funq_server.runner import RunnerInjector
+
+
+class MacRunnerInjector(RunnerInjector):
+
+    def __init__(self, library_path, args, env):
+        RunnerInjector.__init__(self, library_path, args, env)
+        env['DYLD_FORCE_FLAT_NAMESPACE'] = '1'
+        if 'DYLD_INSERT_LIBRARIES' in env:
+            env['DYLD_INSERT_LIBRARIES'] += ':' + self.library_path
+        else:
+            env['DYLD_INSERT_LIBRARIES'] = self.library_path

--- a/server/setup.py
+++ b/server/setup.py
@@ -11,6 +11,7 @@ import sys
 import platform
 
 IS_WINDOWS = platform.system() == 'Windows'
+IS_MAC = platform.system() == 'Darwin'
 
 if sys.version_info < (2, 7):
     sys.exit("Python version must be > 2.7")
@@ -56,6 +57,8 @@ class build_libfunq(Command):
         
         if IS_WINDOWS:
             self.funqlib_name = 'Funq.dll'
+        elif IS_MAC:
+            self.funqlib_name = 'libFunq.dylib'
         else:
             self.funqlib_name = 'libFunq.so'
 


### PR DESCRIPTION
- Add initial support for MacOS
- Fix flake8 errors (missing python3 compatibility)
- Add CI jobs for various combinations of Linux/MacOS, Py2/Py3 and Qt4/Qt5

![grafik](https://user-images.githubusercontent.com/5374821/45818897-4ec60b00-bce3-11e8-9bfc-e0d6cc1956d7.png)

Notes:
- Functional tests are disabled for Qt5 because PySide is Qt4-only. There is now PySide2 available (which is Qt5), but it's still a mess because it's available only for Qt 5.11, which would mean that `funq` must also be compiled with Qt 5.11. I think it would be much better to implement the testing application in C++ instead of Python, then we can easily compile it with the same version as `funq` and get rid of the annoying dependency to PySide. Or are there reasons against this?
- I didn't add jobs with Qt4 on MacOS because it seems that Qt4 is no longer available with homebrew.
- Even if `funq` now also compiles on MacOS, I don't know if it actually works because on Mac we only have Qt5 and thus no PySide, so I can't run functional tests. Once the dependency to PySide is removed, I could continue working on MacOS support.