### PR TITLE
Fix failed tests on MacOS and Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,5 +62,4 @@ script:
   - cd tests-functionnal/funq-test-app && qmake && make -j4 && cd ../..
   - cd client && $PYTHON setup.py test; cd ..
   - make -C server/tests/ check
-  # Functional tests are not working yet on MacOS...
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cd tests-functionnal && nosetests && cd .. ; fi
+  - cd tests-functionnal && nosetests && cd ..

--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,7 @@ Known restrictions
 ==================
 
 Funq currently works with python >= 2.7 (it is fully compatible with python 3),
-Qt4 and Qt5 on GNU/Linux.
+Qt4 and Qt5 on GNU/Linux and macOS.
 
 It also works on Windows, but only with Python 2.7 out of the box. With
 Python 3, the tested application has to be compiled with libFunq because the

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ test: off
 deploy: off
 
 init:
-  - set PATH=C:/Qt/5.9/mingw53_32/bin;C:/Qt/Tools/mingw530_32/bin;%PATH%
+  - set PATH=C:/Qt/5.11/mingw53_32/bin;C:/Qt/Tools/mingw530_32/bin;%PATH%
 
 install:
   - cp C:/Qt/Tools/mingw530_32/bin/mingw32-make.exe C:/Qt/Tools/mingw530_32/bin/make.exe
@@ -15,5 +15,5 @@ install:
 
 build_script:
   - cd client && python setup.py test && cd ..
-# TODO:  - make -C server/tests/ check
-# TODO:  - cd tests-functionnal && nosetests
+  - make -C server/tests/ check
+  - cd tests-functionnal && nosetests && cd ..

--- a/client/funq/client.py
+++ b/client/funq/client.py
@@ -90,11 +90,11 @@ class FunqClient(object):
 
         self.aliases = aliases
 
-        self._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-
         def connect():
             """ try to connect """
             try:
+                self._socket = socket.socket(socket.AF_INET,
+                                             socket.SOCK_STREAM)
                 self._socket.connect((host, port))
                 return True
             except socket.error as e:


### PR DESCRIPTION
On AppVeyor I updated to Qt 5.11 because some tests failed with Qt 5.9. I also experienced issues with Qt 5.5 on my Linux machine, so it seems something is really not working properly with Qt versions somewhere between 5.2 and 5.11 :( Maybe I can take a look at that issue later.

On MacOS, there was an issue with the TCP socket. When creating a new socket object for every connection attempt, it works properly. See https://stackoverflow.com/questions/43643876/python-socket-invalid-argument

With these two changes, all tests are now passing also on MacOS and Windows, so I enabled all tests in CI configurations. Although it's possible that one test could sometimes fail because of #39, but it seems to fail only rarely.