### PR TITLE
Refactor libFunq injector to make it more reliable

### DIFF
--- a/server/libFunq/WindowsInjector.cpp
+++ b/server/libFunq/WindowsInjector.cpp
@@ -32,15 +32,26 @@ The fact that you are presently reading this means that you have had
 knowledge of the CeCILL v2.1 license and that you accept its terms.
 */
 
+#include <QCoreApplication>
 #include "WindowsInjector.h"
 #include "funq.h"
+
+static void inject() {
+    // Wait until QApplication instance exists! Many Qt features must not be used before
+    // QApplication is initialized (could lead to strange and fatal errors), so we don't
+    // use Qt at all until QCoreApplication::startingUp() returns true.
+    while (QCoreApplication::startingUp()) {
+        Sleep(50); // wait 50ms
+    }
+    Funq::activate();
+}
 
 extern "C" int __stdcall DllMain( HINSTANCE , DWORD fdwReason, LPVOID  ) {
 
     switch( fdwReason )
     {
         case DLL_PROCESS_ATTACH:
-            Funq::activate();
+            inject();
             break;
         case DLL_PROCESS_DETACH:
             break;

--- a/server/libFunq/funq.cpp
+++ b/server/libFunq/funq.cpp
@@ -56,7 +56,8 @@ Funq::Funq(Funq::MODE mode, const QHostAddress & host, int port) :
     Q_ASSERT(!_instance);
     _instance = this;
 
-    // this is needed for the dll injection under Windows
+    // Move event processing of this thread (i.e. invoking funqInit()) to the thread of
+    // QApplication because the injection was performed in a dedicated thread.
     moveToThread(qApp->thread());
 
     QTimer::singleShot(0, this, SLOT(funqInit()));

--- a/tests-functionnal/funq-test-app/main.cpp
+++ b/tests-functionnal/funq-test-app/main.cpp
@@ -45,6 +45,14 @@ int main(int argc, char* argv[])
 {
     QApplication app(argc, argv);
 
+    if (app.arguments().contains("--show-message-box-at-startup")) {
+        // This is needed to test if the injection of libFunq also works if Qt's main
+        // event loop is not called directly at application startup. A message box blocks
+        // the whole application, so by closing this dialog with funq we can see if funq
+        // was successfully injected into the blocking application.
+        QMessageBox::information(0, "funq", "click me away");
+    }
+
     MainWindow win;
     win.addDialogButton("click", &execDialog<ClickDialog>);
     win.addDialogButton("doubleclick", &execDialog<DoubleClickDialog>);

--- a/tests-functionnal/test_injection.py
+++ b/tests-functionnal/test_injection.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: SCLE SFE
+# Contributors: https://github.com/parkouss/funq/graphs/contributors
+#
+# This software is a computer program whose purpose is to test graphical
+# applications written with the QT framework (http://qt.digia.com/).
+#
+# This software is governed by the CeCILL v2.1 license under French law and
+# abiding by the rules of distribution of free software.  You can  use,
+# modify and/ or redistribute the software under the terms of the CeCILL
+# license as circulated by CEA, CNRS and INRIA at the following URL
+# "http://www.cecill.info".
+#
+# As a counterpart to the access to the source code and  rights to copy,
+# modify and redistribute granted by the license, users are provided only
+# with a limited warranty  and the software's author,  the holder of the
+# economic rights,  and the successive licensors  have only  limited
+# liability.
+#
+# In this respect, the user's attention is drawn to the risks associated
+# with loading,  using,  modifying and/or developing or reproducing the
+# software by the user in light of its specific status of free software,
+# that may mean  that it is complicated to manipulate,  and  that  also
+# therefore means  that it is reserved for developers  and  experienced
+# professionals having in-depth computer knowledge. Users are therefore
+# encouraged to load and test the software's suitability as regards their
+# requirements in conditions enabling the security of their systems and/or
+# data to be ensured and,  more generally, to use and operate it in the
+# same conditions as regards security.
+#
+# The fact that you are presently reading this means that you have had
+# knowledge of the CeCILL v2.1 license and that you accept its terms.
+
+from base import AppTestCase
+from funq.errors import FunqError
+
+class TestInjection(AppTestCase):
+
+    def setUp(self):
+        # Show a blocking message box *before* Qt's main event loop is entered!
+        self.__app_config__.args = ['--show-message-box-at-startup']
+        def restore_args():
+            self.__app_config__.args = []
+        self.addCleanup(restore_args)
+        super(TestInjection, self).setUp()
+
+    def test_close_blocking_msgbox_at_startup(self):
+        """
+        Test if the injection also works if Qt's main event loop was not
+        entered yet because of a blocking message box.
+        """
+        with self.assertRaises(FunqError):
+            # the main window must NOT be available yet!
+            self.funq.widget(path='mainWindow::QWidget', timeout=2.0)
+        # close the blocking message box
+        btn = self.funq.widget(path='QMessageBox::qt_msgbox_buttonbox::QPushButton')
+        btn.click()
+        # now the main window should be visible
+        window = self.funq.widget(path='mainWindow::QWidget')
+        self.assertEquals(window.properties()['visible'], True)


### PR DESCRIPTION
- On POSIX systems, use a static constructor and a temporary thread for the injection. This way `libFunq` gets initialized successfully even if Qt's main event loop is not entered (for example because of a blocking modal dialog at application startup). Previously the injection did not work if a blocking dialog was opened before entering the main event loop.
- Let the injectors wait with using any Qt features until `QCoreApplication::startingUp()` returns `true` because many Qt features are not safe to be used before a `QApplication` object was created. This may avoid possible strange errors and race conditions at application startup.
- Add functional test for the injection itself (checks if the injection works even if the main event loop is not entered). This test would fail with the old injection mechanism.

This should be the last change needed to get funq initially working for [LibrePCB](https://github.com/LibrePCB/LibrePCB) :smiley:  :tada: