### PR TITLE
Add support for triggering QAction

### DIFF
--- a/client/doc/user_api/funqclient.rst
+++ b/client/doc/user_api/funqclient.rst
@@ -25,6 +25,8 @@ Example::
 
 .. autoclass:: FunqClient
 
+  .. automethod:: FunqClient.action
+
   .. automethod:: FunqClient.widget
 
   .. automethod:: FunqClient.active_widget

--- a/client/doc/user_api/widgets_models.rst
+++ b/client/doc/user_api/widgets_models.rst
@@ -19,6 +19,22 @@ The Object base class
   .. automethod:: Object.call_slot
 
 
+The Action base class
+---------------------
+
+An Action is often obtained with :meth:`funq.client.FunqClient.action` .
+
+Example::
+
+  my_action = self.funq.action('my_action')
+
+.. inheritance-diagram:: Action
+
+.. autoclass:: Action
+
+  .. automethod:: Action.trigger
+
+
 The Widget base class
 ---------------------
 

--- a/client/funq/models.py
+++ b/client/funq/models.py
@@ -237,6 +237,28 @@ class Object(object):
         )['result_slot']
 
 
+class Action(Object):
+
+    """
+    Allow to manipulate a QAction or derived.
+    """
+
+    def trigger(self, blocking=True, wait_for_enabled=10.0):
+        """
+        Trigger the QAction. If wait_for_enabled is > 0 (default), it will wait
+        until the action becomes active (enabled and visible) before triggering
+        it. If blocking is True (default), funq waits until the triggered
+        action has completed (synchronous trigger). For actions which are
+        blocking by themself (e.g. actions which open a modal dialog), you must
+        set blocking to False (asynchronous trigger), otherwise funq freezes.
+        """
+        if wait_for_enabled > 0.0:
+            self.wait_for_properties({'enabled': True, 'visible': True},
+                                     timeout=wait_for_enabled)
+        self.client.send_command('action_trigger', oid=self.oid,
+                                 blocking=blocking)
+
+
 class Widget(Object):
 
     """

--- a/server/libFunq/player.cpp
+++ b/server/libFunq/player.cpp
@@ -36,6 +36,7 @@ knowledge of the CeCILL v2.1 license and that you accept its terms.
 #include <QMetaMethod>
 #include <QStringList>
 #include <QWidget>
+#include <QAction>
 #include "objectpath.h"
 #include <QApplication>
 #include <QMouseEvent>
@@ -479,6 +480,21 @@ QtJson::JsonObject Player::widgets_list(const QtJson::JsonObject & command) {
 QtJson::JsonObject Player::quit(const QtJson::JsonObject &) {
     if (qApp) {
         qApp->quit();
+    }
+    QtJson::JsonObject result;
+    return result;
+}
+
+QtJson::JsonObject Player::action_trigger(const QtJson::JsonObject & command) {
+    WidgetLocatorContext<QAction> ctx(this, command, "oid");
+    if (ctx.hasError()) { return ctx.lastError; }
+    bool blocking = command["blocking"].toBool();
+    if (blocking) {
+        // block until QAction::trigger() returns
+        ctx.widget->trigger();
+    } else {
+        // trigger the action, but return immediately
+        QTimer::singleShot(0, ctx.widget, SLOT(trigger()));
     }
     QtJson::JsonObject result;
     return result;

--- a/server/libFunq/player.h
+++ b/server/libFunq/player.h
@@ -82,6 +82,7 @@ public slots:
     QtJson::JsonObject active_widget(const QtJson::JsonObject & command);
     QtJson::JsonObject object_properties(const QtJson::JsonObject & command);
     QtJson::JsonObject object_set_properties(const QtJson::JsonObject & command);
+    QtJson::JsonObject action_trigger(const QtJson::JsonObject & command);
     QtJson::JsonObject widgets_list(const QtJson::JsonObject & command);
     QtJson::JsonObject widget_click(const QtJson::JsonObject & command);
     QtJson::JsonObject widget_close(const QtJson::JsonObject & command);

--- a/tests-functionnal/funq-test-app/main.cpp
+++ b/tests-functionnal/funq-test-app/main.cpp
@@ -54,6 +54,7 @@ int main(int argc, char* argv[])
     }
 
     MainWindow win;
+    win.addDialogButton("action", &execDialog<ActionDialog>);
     win.addDialogButton("click", &execDialog<ClickDialog>);
     win.addDialogButton("doubleclick", &execDialog<DoubleClickDialog>);
     win.addDialogButton("keyclick", &execDialog<KeyClickDialog>);

--- a/tests-functionnal/funq-test-app/widgets.h
+++ b/tests-functionnal/funq-test-app/widgets.h
@@ -56,6 +56,38 @@ class SimpleDialog : public QDialog {
         }
 };
 
+class ActionDialog : public SimpleDialog {
+        Q_OBJECT
+    public:
+        ActionDialog(QLabel* statusLabel, QWidget* parent) :
+            SimpleDialog(statusLabel, parent) {
+            QMenuBar* bar = new QMenuBar(this);
+            QMenu* menu = bar->addMenu("menu");
+
+            QAction* nonblockingAction = new QAction("nonblocking", this);
+            nonblockingAction->setObjectName("nonblockingAction");
+            connect(nonblockingAction, SIGNAL(triggered()), this, SLOT(nonblockingActionTriggered()));
+            addAction(nonblockingAction);
+            menu->addAction(nonblockingAction);
+
+            QAction* blockingAction = new QAction("blocking", this);
+            blockingAction->setObjectName("blockingAction");
+            connect(blockingAction, SIGNAL(triggered()), this, SLOT(blockingActionTriggered()));
+            addAction(blockingAction);
+            menu->addAction(blockingAction);
+        }
+
+    private slots:
+        void nonblockingActionTriggered() {
+            showResult("nonblocking triggered !");
+        }
+
+        void blockingActionTriggered() {
+            showResult("blocking triggered !");
+            QMessageBox::information(0, "funq", "click me away"); // blocking!
+        }
+};
+
 class ClickDialog : public SimpleDialog {
         Q_OBJECT
     public:

--- a/tests-functionnal/test_action.py
+++ b/tests-functionnal/test_action.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: SCLE SFE
+# Contributor: Julien Pagès <j.parkouss@gmail.com>
+#
+# This software is a computer program whose purpose is to test graphical
+# applications written with the QT framework (http://qt.digia.com/).
+#
+# This software is governed by the CeCILL v2.1 license under French law and
+# abiding by the rules of distribution of free software.  You can  use,
+# modify and/ or redistribute the software under the terms of the CeCILL
+# license as circulated by CEA, CNRS and INRIA at the following URL
+# "http://www.cecill.info".
+#
+# As a counterpart to the access to the source code and  rights to copy,
+# modify and redistribute granted by the license, users are provided only
+# with a limited warranty  and the software's author,  the holder of the
+# economic rights,  and the successive licensors  have only  limited
+# liability.
+#
+# In this respect, the user's attention is drawn to the risks associated
+# with loading,  using,  modifying and/or developing or reproducing the
+# software by the user in light of its specific status of free software,
+# that may mean  that it is complicated to manipulate,  and  that  also
+# therefore means  that it is reserved for developers  and  experienced
+# professionals having in-depth computer knowledge. Users are therefore
+# encouraged to load and test the software's suitability as regards their
+# requirements in conditions enabling the security of their systems and/or
+# data to be ensured and,  more generally, to use and operate it in the
+# same conditions as regards security.
+#
+# The fact that you are presently reading this means that you have had
+# knowledge of the CeCILL v2.1 license and that you accept its terms.
+
+from base import AppTestCase
+
+class TestAction(AppTestCase):
+
+    def test_blocking_trigger_to_nonblocking_action(self):
+        self.start_dialog('action')
+        action = self.funq.action(path='mainWindow::ActionDialog::nonblockingAction')
+        action.trigger(blocking=True)
+        self.assertEquals(self.get_status_text(), 'nonblocking triggered !')
+
+    def test_nonblocking_trigger_to_blocking_action(self):
+        self.start_dialog('action')
+        action = self.funq.action(path='mainWindow::ActionDialog::blockingAction')
+        action.trigger(blocking=False)
+        # close the blocking message box
+        btn = self.funq.widget(path='QMessageBox::qt_msgbox_buttonbox::QPushButton')
+        btn.click()
+        # now the status text must be updated
+        self.assertEquals(self.get_status_text(), 'blocking triggered !')


### PR DESCRIPTION
Allows to trigger QActions like following:

```python
action = funq.action('myActionAlias')  # blocks until the action is enabled and visible
action.trigger(blocking=True)  # blocks until the action is executed completely
```

With the `blocking` parameter it's possible to choose between synchronous and asynchronous triggering. Synchronous is the default because this way the action is guaranteed to be executed after `trigger()` returns. But if the action executes something blocking (e.g. opens a `QMessageBox` or so), asynchronous calls must be used, otherwise the funq server freezes (because `QAction::trigger()` never returns).

Fixes #43 