### PR TITLE
Test more Qt versions on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,16 @@ matrix:
   fast_finish: true
   include:
 
+    # MacOS Qt5 Python2
+    - os: osx
+      language: cpp
+      env: QT_SELECT=5 PYTHON=python2
+
+    # MacOS Qt5 Python3
+    - os: osx
+      language: cpp
+      env: QT_SELECT=5 PYTHON=python3
+
     # Linux Qt4 Python2.7
     - os: linux
       dist: trusty
@@ -25,29 +35,69 @@ matrix:
       python: 3.4
       env: QT_SELECT=4 PYTHON=python
 
-    # Linux Qt5 Python2.7
+    # Linux Qt5.2.1 Python2.7
     - os: linux
       dist: trusty
       language: python
       python: 2.7
-      env: QT_SELECT=5 PYTHON=python
+      env: QT_SELECT=5.2.1 PYTHON=python
 
-    # Linux Qt5 Python3.4
+    # Linux Qt5.3.2 Python3.4
     - os: linux
       dist: trusty
       language: python
       python: 3.4
-      env: QT_SELECT=5 PYTHON=python
+      env: QT_SELECT=5.3.2 PYTHON=python
 
-    # MacOS Qt5 Python2
-    - os: osx
-      language: cpp
-      env: QT_SELECT=5 PYTHON=python2
+    # Linux Qt5.4.2 Python2.7
+    - os: linux
+      dist: trusty
+      language: python
+      python: 2.7
+      env: QT_SELECT=5.4.2 PYTHON=python
 
-    # MacOS Qt5 Python3
-    - os: osx
-      language: cpp
-      env: QT_SELECT=5 PYTHON=python3
+    # Linux Qt5.5.1 Python3.4
+    - os: linux
+      dist: trusty
+      language: python
+      python: 3.4
+      env: QT_SELECT=5.5.1 PYTHON=python
+
+    # Linux Qt5.6.3 Python2.7
+    - os: linux
+      dist: trusty
+      language: python
+      python: 2.7
+      env: QT_SELECT=5.6.3 PYTHON=python
+
+    # Linux Qt5.7.1 Python3.4
+    - os: linux
+      dist: trusty
+      language: python
+      python: 3.4
+      env: QT_SELECT=5.7.1 PYTHON=python
+
+
+    # Linux Qt5.8 Python2.7
+    - os: linux
+      dist: trusty
+      language: python
+      python: 2.7
+      env: QT_SELECT=5.8 PYTHON=python
+
+    # Linux Qt5.9.6 Python3.4
+    - os: linux
+      dist: trusty
+      language: python
+      python: 3.4
+      env: QT_SELECT=5.9.6 PYTHON=python
+
+    # Linux Qt5.10.1 Python2.7
+    - os: linux
+      dist: trusty
+      language: python
+      python: 2.7
+      env: QT_SELECT=5.10.1 PYTHON=python
 
 install:
   - source ./ci/install_dependencies.sh # source required because of exports

--- a/ci/install_dependencies.sh
+++ b/ci/install_dependencies.sh
@@ -8,16 +8,24 @@ if [[ "${TRAVIS_OS_NAME-}" == "linux" ]]
 then
 
   # common
-  sudo apt-get update -qq
-  sudo apt-get install -qq build-essential xvfb
+  sudo apt-get update -q
+  sudo apt-get install -q build-essential xvfb
 
   # qt
   if [[ "$QT_SELECT" == "4" ]]
   then
-    sudo apt-get install -qq libqt4-dev qt4-dev-tools
-  elif [[ "$QT_SELECT" == "5" ]]
-  then
-    sudo apt-get install -qq qtbase5-dev qtdeclarative5-dev qtdeclarative5-qtquick2-plugin qttools5-dev-tools
+    sudo apt-get install -q libqt4-dev qt4-dev-tools
+  else
+    # Add corresponding PPA from https://launchpad.net/~beineri
+    MAJOR=`echo "$QT_SELECT" | cut -d'.' -f 1`
+    MINOR=`echo "$QT_SELECT" | cut -d'.' -f 2`
+    PATCH=`echo "$QT_SELECT" | cut -d'.' -f 3`
+    PREFIX="" && [[ "$MINOR" -ge 10 ]] && PREFIX="-"
+    SEPARATOR="" && [[ "$MINOR" -ge 10 ]] && SEPARATOR="."
+    sudo add-apt-repository "ppa:beineri/opt-qt${PREFIX}${MAJOR}${SEPARATOR}${MINOR}${SEPARATOR}${PATCH}-trusty" -y
+    sudo apt-get update -q
+    sudo apt-get install -q "qt${MAJOR}${MINOR}base" "qt${MAJOR}${MINOR}tools" "qt${MAJOR}${MINOR}declarative"
+    source "/opt/qt${MAJOR}${MINOR}/bin/qt${MAJOR}${MINOR}-env.sh"
   fi
 
   # python packages

--- a/server/libFunq/libFunq.pri
+++ b/server/libFunq/libFunq.pri
@@ -1,6 +1,7 @@
 include(../protocole/protocole.pri)
 
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets quick
+QT += testlib
 
 INCLUDEPATH += $${PWD}
 

--- a/server/libFunq/shortcutresponse.cpp
+++ b/server/libFunq/shortcutresponse.cpp
@@ -36,6 +36,7 @@ knowledge of the CeCILL v2.1 license and that you accept its terms.
 #include "player.h"
 #include <QApplication>
 #include <QKeyEvent>
+#include <QtTest>
 
 ShortcutResponse::ShortcutResponse(JsonClient * client, const QtJson::JsonObject & command)
         : DelayedResponse(client, command), m_target(NULL) {
@@ -77,16 +78,14 @@ void ShortcutResponse::execute(int call) {
             uint key = m_binding[i];
             Qt::KeyboardModifiers modifiers = static_cast<Qt::KeyboardModifiers>(key & Qt::KeyboardModifierMask);
             key = key & ~Qt::KeyboardModifierMask;
-
-            qApp->postEvent(m_target, new QKeyEvent(QKeyEvent::KeyPress, key, modifiers));
+            QTest::keyPress(m_target, static_cast<Qt::Key>(key), modifiers);
         }
     } else if (call == 3) {
         for (uint i = 0; i < m_binding.count(); ++i) {
             uint key = m_binding[i];
             Qt::KeyboardModifiers modifiers = static_cast<Qt::KeyboardModifiers>(key & Qt::KeyboardModifierMask);
             key = key & ~Qt::KeyboardModifierMask;
-
-            qApp->postEvent(m_target, new QKeyEvent(QKeyEvent::KeyRelease, key, modifiers));
+            QTest::keyRelease(m_target, static_cast<Qt::Key>(key), modifiers);
         }
     } else if (call == 4) {
         m_target->releaseKeyboard();


### PR DESCRIPTION
Because I experienced issues on Linux with Qt versions >= 5.5, I extended Travis-CI to test with all major Qt versions so we can detect such issues in future.

Of course I also fixed the actual issue. The keyboard shortcut simulation didn't work, but when using the `keyPress()` and `keyRelease()` functions from `QTest`, it works properly. I think it makes sense anyway to use QTest for simulating user input, because that library is created intended for that purpose.

See also commit messages for details.

CI job matrix without the keyboard shortcut bugfix:
![grafik](https://user-images.githubusercontent.com/5374821/46910178-57a3a880-cf40-11e8-9f3f-5a4bd4a32ca9.png)

And with the bugfix:
![grafik](https://user-images.githubusercontent.com/5374821/46910237-532bbf80-cf41-11e8-919f-e8c013a7c8f3.png)
