### PR TITLE
Add support for right/middle click

### DIFF
--- a/client/funq/models.py
+++ b/client/funq/models.py
@@ -265,29 +265,31 @@ class Widget(Object):
     Allow to manipulate a QWidget or derived.
     """
 
-    def click(self, wait_for_enabled=10.0):
+    def click(self, wait_for_enabled=10.0, btn='left'):
         """
-        Click on the widget. If wait_for_enabled is > 0 (default), it will wait
-        until the widget become active (enabled and visible) before sending
-        click.
-        """
-        if wait_for_enabled > 0.0:
-            self.wait_for_properties({'enabled': True, 'visible': True},
-                                     timeout=wait_for_enabled)
-        self.client.send_command('widget_click', oid=self.oid)
+        Click on the widget.
 
-    def rclick(self, wait_for_enabled=10.0):
-        """
-        Right click on the widget. If wait_for_enabled is > 0 (default), it
-        will wait until the widget become active (enabled and visible) before
-        sending click.
+        If wait_for_enabled is > 0 (default), it will wait until the widget
+        become active (enabled and visible) before sending click.
+
+        The target mouse button can be configured with the `btn` parameter: It
+        can be either 'left', 'middle' or 'right'. Default is 'left'.
+
         """
         if wait_for_enabled > 0.0:
             self.wait_for_properties({'enabled': True, 'visible': True},
                                      timeout=wait_for_enabled)
+        if btn == 'left':
+            action = 'click'
+        elif btn == 'right':
+            action = 'rightclick'
+        elif btn == 'middle':
+            action = 'middleclick'
+        else:
+            raise ValueError('Invalid mouse button: %s', btn)
         self.client.send_command('widget_click',
                                  oid=self.oid,
-                                 mouseAction='rightclick')
+                                 mouseAction=action)
 
     def dclick(self, wait_for_enabled=10.0):
         """
@@ -406,7 +408,7 @@ class ModelItem(TreeItem):
         """
         self._action("edit")
 
-    def click(self, origin="center", offset_x=0, offset_y=0):
+    def click(self, origin="center", offset_x=0, offset_y=0, btn="left"):
         """
         Click on this item.
 
@@ -416,24 +418,19 @@ class ModelItem(TreeItem):
                          Negative value allowed.
         :param offset_y: y position relative to the origin.
                          Negative value allowed.
+        :param btn: The mouse button to click.
+                    Available values: "left", "middle" or "right".
         """
+        if btn == "left":
+            action = "click"
+        elif btn == "right":
+            action = "rightclick"
+        elif btn == "middle":
+            action = "middleclick"
+        else:
+            raise ValueError("Invalid mouse button: %s", btn)
         self._action(
-            "click", origin=origin, offset_x=offset_x, offset_y=offset_y
-        )
-
-    def rclick(self, origin="center", offset_x=0, offset_y=0):
-        """
-        Right click on this item.
-
-        :param origin: Origin of the cursor coordinates of the ModelItem
-                       object. Availables values: "center", "left" or "right".
-        :param offset_x: x position relative to the origin.
-                         Negative value allowed.
-        :param offset_y: y position relative to the origin.
-                         Negative value allowed.
-        """
-        self._action(
-            "rightclick", origin=origin, offset_x=offset_x, offset_y=offset_y
+            action, origin=origin, offset_x=offset_x, offset_y=offset_y
         )
 
     def dclick(self, origin="center", offset_x=0, offset_y=0):
@@ -701,17 +698,19 @@ class GItem(TreeItem):
                                  itemaction=itemaction,
                                  gid=self.gid)
 
-    def click(self):
+    def click(self, btn="left"):
         """
         Click on this gitem.
         """
-        self._action("click")
-
-    def rclick(self):
-        """
-        Right click on this gitem.
-        """
-        self._action("rightclick")
+        if btn == "left":
+            action = "click"
+        elif btn == "right":
+            action = "rightclick"
+        elif btn == "middle":
+            action = "middleclick"
+        else:
+            raise ValueError("Invalid mouse button: %s", btn)
+        self._action(action)
 
     def dclick(self):
         """

--- a/client/funq/models.py
+++ b/client/funq/models.py
@@ -276,6 +276,19 @@ class Widget(Object):
                                      timeout=wait_for_enabled)
         self.client.send_command('widget_click', oid=self.oid)
 
+    def rclick(self, wait_for_enabled=10.0):
+        """
+        Right click on the widget. If wait_for_enabled is > 0 (default), it
+        will wait until the widget become active (enabled and visible) before
+        sending click.
+        """
+        if wait_for_enabled > 0.0:
+            self.wait_for_properties({'enabled': True, 'visible': True},
+                                     timeout=wait_for_enabled)
+        self.client.send_command('widget_click',
+                                 oid=self.oid,
+                                 mouseAction='rightclick')
+
     def dclick(self, wait_for_enabled=10.0):
         """
         Double click on the widget. If wait_for_enabled is > 0 (default), it
@@ -406,6 +419,21 @@ class ModelItem(TreeItem):
         """
         self._action(
             "click", origin=origin, offset_x=offset_x, offset_y=offset_y
+        )
+
+    def rclick(self, origin="center", offset_x=0, offset_y=0):
+        """
+        Right click on this item.
+
+        :param origin: Origin of the cursor coordinates of the ModelItem
+                       object. Availables values: "center", "left" or "right".
+        :param offset_x: x position relative to the origin.
+                         Negative value allowed.
+        :param offset_y: y position relative to the origin.
+                         Negative value allowed.
+        """
+        self._action(
+            "rightclick", origin=origin, offset_x=offset_x, offset_y=offset_y
         )
 
     def dclick(self, origin="center", offset_x=0, offset_y=0):
@@ -678,6 +706,12 @@ class GItem(TreeItem):
         Click on this gitem.
         """
         self._action("click")
+
+    def rclick(self):
+        """
+        Right click on this gitem.
+        """
+        self._action("rightclick")
 
     def dclick(self):
         """

--- a/server/libFunq/player.cpp
+++ b/server/libFunq/player.cpp
@@ -63,27 +63,27 @@ knowledge of the CeCILL v2.1 license and that you accept its terms.
 using namespace ObjectPath;
 
 template<class T>
-void mouse_click(T * w, const QPoint & pos) {
+void mouse_click(T * w, const QPoint & pos, Qt::MouseButton button) {
     QPoint global_pos = w->mapToGlobal(pos);
     qApp->postEvent(w,
         new QMouseEvent(QEvent::MouseButtonPress,
                         pos,
                         global_pos,
-                        Qt::LeftButton,
+                        button,
                         Qt::NoButton,
                         Qt::NoModifier));
     qApp->postEvent(w,
         new QMouseEvent(QEvent::MouseButtonRelease,
                         pos,
                         global_pos,
-                        Qt::LeftButton,
+                        button,
                         Qt::NoButton,
                         Qt::NoModifier));
 }
 
 template<class T>
 void mouse_dclick(T * w, const QPoint & pos) {
-    mouse_click(w, pos);
+    mouse_click(w, pos, Qt::LeftButton);
     qApp->postEvent(w,
         new QMouseEvent(QEvent::MouseButtonDblClick,
                         pos,
@@ -507,8 +507,10 @@ QtJson::JsonObject Player::widget_click(const QtJson::JsonObject & command) {
     QPoint pos = ctx.widget->rect().center();
     if (action == "doubleclick") {
         mouse_dclick(ctx.widget, pos);
+    } else if (action == "rightclick") {
+        mouse_click(ctx.widget, pos, Qt::RightButton);
     } else {
-        mouse_click(ctx.widget, pos);
+        mouse_click(ctx.widget, pos, Qt::LeftButton);
     }
     QtJson::JsonObject result;
     return result;
@@ -523,7 +525,7 @@ QtJson::JsonObject Player::quick_item_click(const QtJson::JsonObject & command) 
 
     QPoint sPos = ctx.item->mapToScene(relativeCenter).toPoint();
 
-    mouse_click(ctx.window, sPos);
+    mouse_click(ctx.window, sPos, Qt::LeftButton);
     QtJson::JsonObject result;
     return result;
 #else
@@ -604,7 +606,9 @@ QtJson::JsonObject Player::model_item_action(const QtJson::JsonObject & command)
     } else if (itemaction == "edit") {
         emit emit_model_item_action(itemaction, ctx.widget, index);
     } else if (itemaction == "click") {
-        mouse_click(ctx.widget->viewport(), cursorPosition);
+        mouse_click(ctx.widget->viewport(), cursorPosition, Qt::LeftButton);
+    } else if (itemaction == "rightclick") {
+        mouse_click(ctx.widget->viewport(), cursorPosition, Qt::RightButton);
     } else if (itemaction == "doubleclick") {
         mouse_dclick(ctx.widget->viewport(), cursorPosition);
     } else {
@@ -635,11 +639,11 @@ QtJson::JsonObject Player::model_gitem_action(const QtJson::JsonObject & command
     QString itemaction = command["itemaction"].toString();
 
     QPoint viewPos = ctx.widget->mapFromScene(item->mapToScene(item->boundingRect().center()));
-    if (itemaction == "click") {
+    if (itemaction == "click" || itemaction == "rightclick") {
         if (ctx.widget->scene() && ctx.widget->scene()->mouseGrabberItem()) {
             ctx.widget->scene()->mouseGrabberItem()->ungrabMouse();
         }
-        mouse_click(ctx.widget->viewport(), viewPos);
+        mouse_click(ctx.widget->viewport(), viewPos, itemaction == "rightclick" ? Qt::RightButton : Qt::LeftButton);
     } else if (itemaction == "doubleclick") {
         if (ctx.widget->scene() && ctx.widget->scene()->mouseGrabberItem()) {
             ctx.widget->scene()->mouseGrabberItem()->ungrabMouse();
@@ -759,7 +763,7 @@ QtJson::JsonObject Player::headerview_click(const QtJson::JsonObject & command) 
         mousePos.setX(ctx.widget->width()/2);
         mousePos.setY(pos + ctx.widget->offset() + 5);
     }
-    mouse_click(ctx.widget->viewport(), mousePos);
+    mouse_click(ctx.widget->viewport(), mousePos, Qt::LeftButton);
     QtJson::JsonObject result;
     return result;
 }

--- a/server/libFunq/player.cpp
+++ b/server/libFunq/player.cpp
@@ -509,6 +509,8 @@ QtJson::JsonObject Player::widget_click(const QtJson::JsonObject & command) {
         mouse_dclick(ctx.widget, pos);
     } else if (action == "rightclick") {
         mouse_click(ctx.widget, pos, Qt::RightButton);
+    } else if (action == "middleclick") {
+        mouse_click(ctx.widget, pos, Qt::MiddleButton);
     } else {
         mouse_click(ctx.widget, pos, Qt::LeftButton);
     }
@@ -609,6 +611,8 @@ QtJson::JsonObject Player::model_item_action(const QtJson::JsonObject & command)
         mouse_click(ctx.widget->viewport(), cursorPosition, Qt::LeftButton);
     } else if (itemaction == "rightclick") {
         mouse_click(ctx.widget->viewport(), cursorPosition, Qt::RightButton);
+    } else if (itemaction == "middleclick") {
+        mouse_click(ctx.widget->viewport(), cursorPosition, Qt::MiddleButton);
     } else if (itemaction == "doubleclick") {
         mouse_dclick(ctx.widget->viewport(), cursorPosition);
     } else {
@@ -639,11 +643,17 @@ QtJson::JsonObject Player::model_gitem_action(const QtJson::JsonObject & command
     QString itemaction = command["itemaction"].toString();
 
     QPoint viewPos = ctx.widget->mapFromScene(item->mapToScene(item->boundingRect().center()));
-    if (itemaction == "click" || itemaction == "rightclick") {
+    if (itemaction == "click" || itemaction == "rightclick" || itemaction == "middleclick") {
         if (ctx.widget->scene() && ctx.widget->scene()->mouseGrabberItem()) {
             ctx.widget->scene()->mouseGrabberItem()->ungrabMouse();
         }
-        mouse_click(ctx.widget->viewport(), viewPos, itemaction == "rightclick" ? Qt::RightButton : Qt::LeftButton);
+        if (itemaction == "rightclick") {
+            mouse_click(ctx.widget->viewport(), viewPos, Qt::RightButton);
+        } else if (itemaction == "middleclick") {
+            mouse_click(ctx.widget->viewport(), viewPos, Qt::MiddleButton);
+        } else {
+            mouse_click(ctx.widget->viewport(), viewPos, Qt::LeftButton);
+        }
     } else if (itemaction == "doubleclick") {
         if (ctx.widget->scene() && ctx.widget->scene()->mouseGrabberItem()) {
             ctx.widget->scene()->mouseGrabberItem()->ungrabMouse();

--- a/tests-functionnal/funq-test-app/main.cpp
+++ b/tests-functionnal/funq-test-app/main.cpp
@@ -56,7 +56,7 @@ int main(int argc, char* argv[])
     MainWindow win;
     win.addDialogButton("action", &execDialog<ActionDialog>);
     win.addDialogButton("click", &execDialog<ClickDialog>);
-    win.addDialogButton("rightclick", &execDialog<RightClickDialog>);
+    win.addDialogButton("widgetclick", &execDialog<WidgetClickDialog>);
     win.addDialogButton("doubleclick", &execDialog<DoubleClickDialog>);
     win.addDialogButton("keyclick", &execDialog<KeyClickDialog>);
     win.addDialogButton("retrieve", &execDialog<RetrieveWidget>);

--- a/tests-functionnal/funq-test-app/main.cpp
+++ b/tests-functionnal/funq-test-app/main.cpp
@@ -56,6 +56,7 @@ int main(int argc, char* argv[])
     MainWindow win;
     win.addDialogButton("action", &execDialog<ActionDialog>);
     win.addDialogButton("click", &execDialog<ClickDialog>);
+    win.addDialogButton("rightclick", &execDialog<RightClickDialog>);
     win.addDialogButton("doubleclick", &execDialog<DoubleClickDialog>);
     win.addDialogButton("keyclick", &execDialog<KeyClickDialog>);
     win.addDialogButton("retrieve", &execDialog<RetrieveWidget>);

--- a/tests-functionnal/funq-test-app/widgets.h
+++ b/tests-functionnal/funq-test-app/widgets.h
@@ -104,6 +104,25 @@ class ClickDialog : public SimpleDialog {
         }
 };
 
+class RightClickDialog : public SimpleDialog {
+        Q_OBJECT
+    public:
+        RightClickDialog(QLabel* statusLabel, QWidget* parent) :
+            SimpleDialog(statusLabel, parent) {
+            QWidget* w = new QWidget();
+            w->resize(100, 100);
+            layout()->addWidget(w);
+        }
+
+        void mouseReleaseEvent(QMouseEvent *e) {
+            if (e->button() == Qt::RightButton) {
+                showResult("right clicked !");
+            } else {
+                showResult("clicked with wrong mouse button :(");
+            }
+        }
+};
+
 class DoubleClickDialog : public SimpleDialog {
         Q_OBJECT
     public:

--- a/tests-functionnal/funq-test-app/widgets.h
+++ b/tests-functionnal/funq-test-app/widgets.h
@@ -104,10 +104,10 @@ class ClickDialog : public SimpleDialog {
         }
 };
 
-class RightClickDialog : public SimpleDialog {
+class WidgetClickDialog : public SimpleDialog {
         Q_OBJECT
     public:
-        RightClickDialog(QLabel* statusLabel, QWidget* parent) :
+        WidgetClickDialog(QLabel* statusLabel, QWidget* parent) :
             SimpleDialog(statusLabel, parent) {
             QWidget* w = new QWidget();
             w->resize(100, 100);
@@ -115,10 +115,14 @@ class RightClickDialog : public SimpleDialog {
         }
 
         void mouseReleaseEvent(QMouseEvent *e) {
-            if (e->button() == Qt::RightButton) {
+            if (e->button() == Qt::LeftButton) {
+                showResult("left clicked !");
+            } else if (e->button() == Qt::RightButton) {
                 showResult("right clicked !");
+            } else if (e->button() == Qt::MiddleButton) {
+                showResult("middle clicked !");
             } else {
-                showResult("clicked with wrong mouse button :(");
+                showResult("clicked with unhandled mouse button :(");
             }
         }
 };

--- a/tests-functionnal/test_click.py
+++ b/tests-functionnal/test_click.py
@@ -42,7 +42,13 @@ class TestClick(AppTestCase):
         btn = self.funq.widget(path='mainWindow::ClickDialog::QPushButton')
         btn.click()
         self.assertEquals(self.get_status_text(), 'clicked !')
-    
+
+    def test_right_click(self):
+        self.start_dialog('rightclick')
+        btn = self.funq.widget(path='mainWindow::RightClickDialog')
+        btn.rclick()
+        self.assertEquals(self.get_status_text(), 'right clicked !')
+
     def test_double_click(self):
         self.start_dialog('doubleclick')
         btn = self.funq.widget(path='mainWindow::DoubleClickDialog')

--- a/tests-functionnal/test_click.py
+++ b/tests-functionnal/test_click.py
@@ -44,17 +44,23 @@ class TestClick(AppTestCase):
         self.assertEquals(self.get_status_text(), 'clicked !')
 
     def test_right_click(self):
-        self.start_dialog('rightclick')
-        btn = self.funq.widget(path='mainWindow::RightClickDialog')
-        btn.rclick()
+        self.start_dialog('widgetclick')
+        btn = self.funq.widget(path='mainWindow::WidgetClickDialog')
+        btn.click(btn='right')
         self.assertEquals(self.get_status_text(), 'right clicked !')
+
+    def test_middle_click(self):
+        self.start_dialog('widgetclick')
+        btn = self.funq.widget(path='mainWindow::WidgetClickDialog')
+        btn.click(btn='middle')
+        self.assertEquals(self.get_status_text(), 'middle clicked !')
 
     def test_double_click(self):
         self.start_dialog('doubleclick')
         btn = self.funq.widget(path='mainWindow::DoubleClickDialog')
         btn.dclick()
         self.assertEquals(self.get_status_text(), 'double clicked !')
-    
+
     @parameterized('sometext', 'Hello this is me !')
     @parameterized('someothertext', 'AAAA BBBBBBBBBBBBBBBBBB CCCCCCCCCCCCCCCCCCCC')
     def test_key_click(self, text):


### PR DESCRIPTION
This fixes #46.

In the server, I made the click function parametrized, so that any mouse button could be used.

Right now, besides the "click" action that already existed, only "rightclick" is exposed. This could be extended later on with a parametrized action (although middle click is probably the only other click action that people might want).

Unfortunately I don't know how to try it out, but at least "python setup.py develop" in the server directory worked.