### PR TITLE
Add some quotes to args and kwargs to prevent failures in build

### DIFF
--- a/client/funq/testcase.py
+++ b/client/funq/testcase.py
@@ -141,8 +141,8 @@ def parameterized(func_suffix, *args, **kwargs):
               print value, named
 
     :param func_suffix: will be used as a suffix for the new method
-    :param \*args: arguments to pass to the new method
-    :param \*\*kwargs: named arguments to pass to the new method
+    :param `*args`: arguments to pass to the new method
+    :param `**kwargs`: named arguments to pass to the new method
     """
     def wrapped(func):
         if not hasattr(func, 'parameters'):


### PR DESCRIPTION
The build is failing because of a flake8 error related to Sphinx syntax, so based on [this documentation](http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#escaping-mechanism), I found a way to prevent the error from flake8.