### PR TITLE
Fix race conditions caused by queued signal/slot connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Random failures of ComboBox.model_items()
+- Race conditions between object_properties and object_set_properties
 
 ## [1.1.5] - 2018-12-06
 ### Added

--- a/server/libFunq/player.cpp
+++ b/server/libFunq/player.cpp
@@ -237,17 +237,6 @@ void dump_graphics_items(const QList<QGraphicsItem *> & items,
 
 Player::Player(QIODevice * device, QObject * parent)
     : JsonClient(device, parent) {
-    connect(this,
-            SIGNAL(emit_object_set_properties(QObject *, const QVariantMap &)),
-            this, SLOT(_object_set_properties(QObject *, const QVariantMap &)),
-            Qt::QueuedConnection);
-    connect(this,
-            SIGNAL(emit_model_item_action(const QString &, QAbstractItemView *,
-                                          const QModelIndex &)),
-            this,
-            SLOT(_model_item_action(const QString &, QAbstractItemView *,
-                                    const QModelIndex &)),
-            Qt::QueuedConnection);
 }
 
 qulonglong Player::registerObject(QObject * object) {
@@ -441,7 +430,7 @@ QtJson::JsonObject Player::object_set_properties(
         return ctx.lastError;
     }
     QVariantMap properties = command["properties"].value<QVariantMap>();
-    emit_object_set_properties(ctx.obj, properties);
+    _object_set_properties(ctx.obj, properties);
     QtJson::JsonObject result;
     return result;
 }
@@ -729,9 +718,9 @@ QtJson::JsonObject Player::model_item_action(
     }
 
     if (itemaction == "select") {
-        emit emit_model_item_action(itemaction, ctx.widget, index);
+        _model_item_action(itemaction, ctx.widget, index);
     } else if (itemaction == "edit") {
-        emit emit_model_item_action(itemaction, ctx.widget, index);
+        _model_item_action(itemaction, ctx.widget, index);
     } else if (itemaction == "click") {
         mouse_click(ctx.widget->viewport(), cursorPosition, Qt::LeftButton);
     } else if (itemaction == "rightclick") {

--- a/server/libFunq/player.h
+++ b/server/libFunq/player.h
@@ -59,12 +59,6 @@ public:
     qulonglong registerObject(QObject * object);
     QObject * registeredObject(const qulonglong & id);
 
-signals:
-    void emit_object_set_properties(QObject * object,
-                                    const QVariantMap & props);
-    void emit_model_item_action(const QString &, QAbstractItemView *,
-                                const QModelIndex &);
-
 public slots:
     /*
      * These slots are automatically transformed into available commands
@@ -123,11 +117,13 @@ protected:
                            "compiled with Qyt Quick.");
     }
 
-private slots:
-    void objectDeleted(QObject * object);
+private:
     void _object_set_properties(QObject * object, const QVariantMap & props);
     void _model_item_action(const QString &, QAbstractItemView *,
                             const QModelIndex &);
+
+private slots:
+    void objectDeleted(QObject * object);
 
 private:
     QHash<qulonglong, QObject *> m_registeredObjects;


### PR DESCRIPTION
I'm not completely sure if it has any disadvantage to replace the queued connections by direct connections, but at least the tests seem to be stable now ;)

Fixes #39.

Note: This conflicts with #54 - if one PR is merged, I'll rebase the other one.