### PR TITLE
Remove duplicate SOURCES/HEADERS in libFunq.pro

### DIFF
--- a/server/tests/libFunq/libFunq.pro
+++ b/server/tests/libFunq/libFunq.pro
@@ -9,9 +9,5 @@ DEFINES += SOURCE_DIR=\\\"$${PWD}/\\\"
 
 SOURCES = test.cpp
 
-SOURCES += ../../libFunq/objectpath.cpp ../../libFunq/player.cpp ../../libFunq/dragndropresponse.cpp ../../libFunq/shortcutresponse.cpp
-
-HEADERS = ../../libFunq/objectpath.h ../../libFunq/player.h ../../libFunq/dragndropresponse.h ../../libFunq/shortcutresponse.h
-
 include(../common.pri)
-include(../../protocole/protocole.pri)
+include(../../libFunq/libFunq.pri)


### PR DESCRIPTION
Applying the same pattern as in `protocole.pro` to avoid listing all source/header files at two locations. Looks like that was a copy&paste mistake to include `protocole.pri` instead of `libFunq.pri`(?).