### PR TITLE
Add support for converting widget coordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Support for grabbing the content of widgets as a picture
+- Support for converting widget coordinates
 
 ### Changed
 - Refactor model/view related classes (moved/renamed several methods)

--- a/client/doc/user_api/widgets_models.rst
+++ b/client/doc/user_api/widgets_models.rst
@@ -64,6 +64,10 @@ Example::
 
   .. automethod:: Widget.grab
 
+  .. automethod:: Widget.map_position_from
+
+  .. automethod:: Widget.map_position_to
+
 Interacting with the data of QT Model/View framework
 ----------------------------------------------------
 

--- a/client/funq/models.py
+++ b/client/funq/models.py
@@ -380,6 +380,45 @@ class Widget(Object):
         data = self.client.send_command('grab', format=format, oid=self.oid)
         return base64.standard_b64decode(data['data'])
 
+    def map_position_from(self, x, y, parent):
+        """
+        Map a given parent's coordinate or global coordinate to a local widget
+        coordinate. See Qt's documentation of `QWidget::mapFrom()` and
+        `QWidget::mapFromGlobal()` for details.
+
+        :param int x: X coordinate relative to parent.
+        :param int y: Y coordinate relative to parent.
+        :param parent: One of this widget's parent (:class:`ModelItem`)
+                       or `None` to map from global coordinates.
+        :return: Local widget coordinates as tuple (X, Y).
+        """
+        parent_oid = parent.oid if parent else None
+        response = self.client.send_command('widget_map_position',
+                                            oid=self.oid,
+                                            parent_oid=parent_oid,
+                                            direction='from', x=x, y=y)
+        return response['x'], response['y']
+
+    def map_position_to(self, x, y, parent):
+        """
+        Map a given widget coordinate to a parent's coordinate or global
+        coordinate. See Qt's documentation of `QWidget::mapTo()` and
+        `QWidget::mapToGlobal()` for details.
+
+        :param int x: Local X coordinate.
+        :param int y: Local Y coordinate.
+        :param parent: One of this widget's parent ([type: :class:`ModelItem`])
+                       or None to map to global coordinates.
+        :return: Coordinates relative to the given parent widget, or
+                 global coordinates as tuple (X, Y).
+        """
+        parent_oid = parent.oid if parent else None
+        response = self.client.send_command('widget_map_position',
+                                            oid=self.oid,
+                                            parent_oid=parent_oid,
+                                            direction='to', x=x, y=y)
+        return response['x'], response['y']
+
 
 class ModelItem(TreeItem):
 

--- a/server/libFunq/player.h
+++ b/server/libFunq/player.h
@@ -90,6 +90,7 @@ public slots:
     QtJson::JsonObject widgets_list(const QtJson::JsonObject & command);
     QtJson::JsonObject widget_click(const QtJson::JsonObject & command);
     QtJson::JsonObject widget_close(const QtJson::JsonObject & command);
+    QtJson::JsonObject widget_map_position(const QtJson::JsonObject & command);
     DelayedResponse * drag_n_drop(const QtJson::JsonObject & command);
     QtJson::JsonObject model(const QtJson::JsonObject & command);
     QtJson::JsonObject model_items(const QtJson::JsonObject & command);

--- a/tests-functionnal/test_widget.py
+++ b/tests-functionnal/test_widget.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: SCLE SFE
+# Contributor: Julien Pagès <j.parkouss@gmail.com>
+#
+# This software is a computer program whose purpose is to test graphical
+# applications written with the QT framework (http://qt.digia.com/).
+#
+# This software is governed by the CeCILL v2.1 license under French law and
+# abiding by the rules of distribution of free software.  You can  use,
+# modify and/ or redistribute the software under the terms of the CeCILL
+# license as circulated by CEA, CNRS and INRIA at the following URL
+# "http://www.cecill.info".
+#
+# As a counterpart to the access to the source code and  rights to copy,
+# modify and redistribute granted by the license, users are provided only
+# with a limited warranty  and the software's author,  the holder of the
+# economic rights,  and the successive licensors  have only  limited
+# liability.
+#
+# In this respect, the user's attention is drawn to the risks associated
+# with loading,  using,  modifying and/or developing or reproducing the
+# software by the user in light of its specific status of free software,
+# that may mean  that it is complicated to manipulate,  and  that  also
+# therefore means  that it is reserved for developers  and  experienced
+# professionals having in-depth computer knowledge. Users are therefore
+# encouraged to load and test the software's suitability as regards their
+# requirements in conditions enabling the security of their systems and/or
+# data to be ensured and,  more generally, to use and operate it in the
+# same conditions as regards security.
+#
+# The fact that you are presently reading this means that you have had
+# knowledge of the CeCILL v2.1 license and that you accept its terms.
+
+from base import AppTestCase
+from funq.testcase import parameterized
+
+
+class TestWidget(AppTestCase):
+
+    def test_map_position_to_from_global(self):
+        btn = self.funq.widget(path='mainWindow::QWidget::click')
+        local_pos = (10, 20)
+        global_pos = btn.map_position_to(*local_pos, parent=None)
+        self.assertNotEquals(global_pos, local_pos)
+        local_pos_2 = btn.map_position_from(*global_pos, parent=None)
+        self.assertEquals(local_pos_2, local_pos)
+
+    def test_map_position_from_to_global(self):
+        btn = self.funq.widget(path='mainWindow::QWidget::click')
+        global_pos = (100, 200)
+        local_pos = btn.map_position_from(*global_pos, parent=None)
+        self.assertNotEquals(local_pos, global_pos)
+        global_pos_2 = btn.map_position_to(*local_pos, parent=None)
+        self.assertEquals(global_pos_2, global_pos)
+
+    def test_map_position_to_from_parent(self):
+        win = self.funq.widget(path='mainWindow')
+        btn = self.funq.widget(path='mainWindow::QWidget::click')
+        local_pos = (10, 20)
+        parent_pos = btn.map_position_to(*local_pos, parent=win)
+        self.assertNotEquals(parent_pos, local_pos)
+        local_pos_2 = btn.map_position_from(*parent_pos, parent=win)
+        self.assertEquals(local_pos_2, local_pos)
+
+    def test_map_position_from_to_parent(self):
+        win = self.funq.widget(path='mainWindow')
+        btn = self.funq.widget(path='mainWindow::QWidget::click')
+        parent_pos = (100, 200)
+        local_pos = btn.map_position_from(*parent_pos, parent=win)
+        self.assertNotEquals(local_pos, parent_pos)
+        parent_pos_2 = btn.map_position_to(*local_pos, parent=win)
+        self.assertEquals(parent_pos_2, parent_pos)


### PR DESCRIPTION
This allows to convert between local widget coordinates and other widget's coordinates or even global coordinates. That's useful for example to locate specific widgets in a screenshot, for example when creating such GIFs (to add the automatic cursor movements) :smile:

![library_manager](https://user-images.githubusercontent.com/5374821/50668949-9044a280-0fc2-11e9-9a17-645b62ade53b.gif)
