### PR TITLE
Add support for moving and resizing widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Support for grabbing the content of widgets as a picture
 - Support for converting widget coordinates
+- Support for moving and resizing widgets
 
 ### Changed
 - Refactor model/view related classes (moved/renamed several methods)

--- a/client/doc/user_api/widgets_models.rst
+++ b/client/doc/user_api/widgets_models.rst
@@ -59,6 +59,10 @@ Example::
   .. automethod:: Widget.drag_n_drop
 
   .. automethod:: Widget.activate_focus
+  
+  .. automethod:: Widget.move
+  
+  .. automethod:: Widget.resize
 
   .. automethod:: Widget.close
 

--- a/client/funq/models.py
+++ b/client/funq/models.py
@@ -364,6 +364,32 @@ class Widget(Object):
         self.client.drag_n_drop(self, src_pos=src_pos, dest_widget=dest_widget,
                                 dest_pos=dest_pos)
 
+    def move(self, x=None, y=None):
+        """
+        Move the widget, using QWidget::move(). One can either only change X or
+        Y coordinate, or both at the same time.
+
+        :param int x: New X coordinate (optional).
+        :param int y: New Y coordinate (optional).
+        :return: New position as tuple (X, Y).
+        """
+        response = self.client.send_command('widget_move', oid=self.oid,
+                                            x=x, y=y)
+        return response['x'], response['y']
+
+    def resize(self, width=None, height=None):
+        """
+        Resize the widget, using QWidget::resize(). One can either only change
+        width or height, or both at the same time.
+
+        :param int width: New width (optional).
+        :param int height: New height (optional).
+        :return: New size as tuple (width, height).
+        """
+        response = self.client.send_command('widget_resize', oid=self.oid,
+                                            width=width, height=height)
+        return response['width'], response['height']
+
     def close(self):
         """
         Ask to close a widget, using QWidget::close().

--- a/server/libFunq/libFunq.pro
+++ b/server/libFunq/libFunq.pro
@@ -7,4 +7,8 @@ isEmpty(PREFIX) { PREFIX = /usr/local }
 target.path = $$PREFIX/bin/
 INSTALLS += target
 
+# Disable deprecation warnings since we want to be backward compatible to Qt4
+# and thus have to use some methods which are deprecated in recent Qt versions.
+DEFINES += QT_NO_DEPRECATED_WARNINGS=1
+
 include(libFunq.pri)

--- a/server/libFunq/player.cpp
+++ b/server/libFunq/player.cpp
@@ -559,6 +559,48 @@ QtJson::JsonObject Player::quick_item_click(
 #endif
 }
 
+QtJson::JsonObject Player::widget_move(const QtJson::JsonObject & command) {
+  WidgetLocatorContext<QWidget> ctx(this, command, "oid");
+  if (ctx.hasError()) {
+      return ctx.lastError;
+  }
+
+  QPoint pos = ctx.widget->pos();
+  if (!command["x"].isNull()) {
+    pos.setX(command["x"].toInt());
+  }
+  if (!command["y"].isNull()) {
+    pos.setY(command["y"].toInt());
+  }
+  ctx.widget->move(pos);
+
+  QtJson::JsonObject result;
+  result["x"] = ctx.widget->x();
+  result["y"] = ctx.widget->y();
+  return result;
+}
+
+QtJson::JsonObject Player::widget_resize(const QtJson::JsonObject & command) {
+  WidgetLocatorContext<QWidget> ctx(this, command, "oid");
+  if (ctx.hasError()) {
+      return ctx.lastError;
+  }
+
+  QSize size = ctx.widget->size();
+  if (!command["width"].isNull()) {
+    size.setWidth(command["width"].toInt());
+  }
+  if (!command["height"].isNull()) {
+    size.setHeight(command["height"].toInt());
+  }
+  ctx.widget->resize(size);
+
+  QtJson::JsonObject result;
+  result["width"] = ctx.widget->width();
+  result["height"] = ctx.widget->height();
+  return result;
+}
+
 QtJson::JsonObject Player::widget_close(const QtJson::JsonObject & command) {
     WidgetLocatorContext<QWidget> ctx(this, command, "oid");
     if (ctx.hasError()) {

--- a/server/libFunq/player.h
+++ b/server/libFunq/player.h
@@ -83,6 +83,8 @@ public slots:
     QtJson::JsonObject action_trigger(const QtJson::JsonObject & command);
     QtJson::JsonObject widgets_list(const QtJson::JsonObject & command);
     QtJson::JsonObject widget_click(const QtJson::JsonObject & command);
+    QtJson::JsonObject widget_move(const QtJson::JsonObject & command);
+    QtJson::JsonObject widget_resize(const QtJson::JsonObject & command);
     QtJson::JsonObject widget_close(const QtJson::JsonObject & command);
     QtJson::JsonObject widget_map_position(const QtJson::JsonObject & command);
     DelayedResponse * drag_n_drop(const QtJson::JsonObject & command);

--- a/server/tests/common.pri
+++ b/server/tests/common.pri
@@ -10,3 +10,7 @@ unix {
 }
 
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets quick
+
+# Disable deprecation warnings since we want to be backward compatible to Qt4
+# and thus have to use some methods which are deprecated in recent Qt versions.
+DEFINES += QT_NO_DEPRECATED_WARNINGS=1

--- a/tests-functionnal/test_widget.py
+++ b/tests-functionnal/test_widget.py
@@ -38,6 +38,70 @@ from funq.testcase import parameterized
 
 class TestWidget(AppTestCase):
 
+    def test_move_x(self):
+        self.start_dialog('widgetclick')
+        widget = self.funq.widget(path='mainWindow::WidgetClickDialog::QWidget')
+        props_before = widget.properties()
+        new_x, new_y = widget.move(x=5)
+        self.assertEquals(new_x, 5)
+        self.assertEquals(new_y, props_before['y'])
+        props_after = widget.properties()
+        self.assertEquals(props_after['x'], new_x)
+        self.assertEquals(props_after['y'], new_y)
+
+    def test_move_y(self):
+        self.start_dialog('widgetclick')
+        widget = self.funq.widget(path='mainWindow::WidgetClickDialog::QWidget')
+        props_before = widget.properties()
+        new_x, new_y = widget.move(y=6)
+        self.assertEquals(new_x, props_before['x'])
+        self.assertEquals(new_y, 6)
+        props_after = widget.properties()
+        self.assertEquals(props_after['x'], new_x)
+        self.assertEquals(props_after['y'], new_y)
+
+    def test_move_xy(self):
+        self.start_dialog('widgetclick')
+        widget = self.funq.widget(path='mainWindow::WidgetClickDialog::QWidget')
+        new_x, new_y = widget.move(x=13, y=37)
+        self.assertEquals(new_x, 13)
+        self.assertEquals(new_y, 37)
+        props_after = widget.properties()
+        self.assertEquals(props_after['x'], new_x)
+        self.assertEquals(props_after['y'], new_y)
+
+    def test_resize_width(self):
+        self.start_dialog('widgetclick')
+        widget = self.funq.widget(path='mainWindow::WidgetClickDialog::QWidget')
+        props_before = widget.properties()
+        new_width, new_height = widget.resize(width=42)
+        self.assertEquals(new_width, 42)
+        self.assertEquals(new_height, props_before['height'])
+        props_after = widget.properties()
+        self.assertEquals(props_after['width'], new_width)
+        self.assertEquals(props_after['height'], new_height)
+
+    def test_resize_height(self):
+        self.start_dialog('widgetclick')
+        widget = self.funq.widget(path='mainWindow::WidgetClickDialog::QWidget')
+        props_before = widget.properties()
+        new_width, new_height = widget.resize(height=24)
+        self.assertEquals(new_width, props_before['width'])
+        self.assertEquals(new_height, 24)
+        props_after = widget.properties()
+        self.assertEquals(props_after['width'], new_width)
+        self.assertEquals(props_after['height'], new_height)
+
+    def test_resize_both(self):
+        self.start_dialog('widgetclick')
+        widget = self.funq.widget(path='mainWindow::WidgetClickDialog::QWidget')
+        new_width, new_height = widget.resize(width=13, height=37)
+        self.assertEquals(new_width, 13)
+        self.assertEquals(new_height, 37)
+        props_after = widget.properties()
+        self.assertEquals(props_after['width'], new_width)
+        self.assertEquals(props_after['height'], new_height)
+
     def test_map_position_to_from_global(self):
         btn = self.funq.widget(path='mainWindow::QWidget::click')
         local_pos = (10, 20)


### PR DESCRIPTION
Adding commands`widget_move` + `widget_resize` and corresponding client methods `Widget.move()` + `Widget.resize()`. Useful for example to test if the application saves and restores the window geometry properly :)