### PR TITLE
Server: Pass build type to "make" instead of "qmake"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ notifications:
     on_success: change
     on_failure: change
 
+services:
+  - xvfb
+
 env:
   global:
     - FUNQ_CXXFLAGS="-Wall -Wextra -Werror"  # make CI fail on warnings
@@ -81,7 +84,6 @@ matrix:
       python: 3.4
       env: QT_SELECT=5.7.1 PYTHON=python
 
-
     # Linux Qt5.8 Python2.7
     - os: linux
       dist: trusty
@@ -102,6 +104,34 @@ matrix:
       language: python
       python: 2.7
       env: QT_SELECT=5.10.1 PYTHON=python
+
+    # Linux Qt5.11.3 Python2.7
+    - os: linux
+      dist: xenial
+      language: python
+      python: 2.7
+      env: QT_SELECT=5.11.3 PYTHON=python
+
+    # Linux Qt5.12.8 Python3.5
+    - os: linux
+      dist: xenial
+      language: python
+      python: 3.5
+      env: QT_SELECT=5.12.8 PYTHON=python
+
+    # Linux Qt5.13.2 Python2.7
+    - os: linux
+      dist: bionic
+      language: python
+      python: 2.7
+      env: QT_SELECT=5.13.2 PYTHON=python
+
+    # Linux Qt5.14.2 Python3.8
+    - os: linux
+      dist: bionic
+      language: python
+      python: 3.8
+      env: QT_SELECT=5.14.2 PYTHON=python
 
 install:
   - source ./ci/install_dependencies.sh # source required because of exports

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,22 +1,34 @@
-os: Windows Server 2012
 build: off
 test: off
 deploy: off
 
 environment:
+  FUNQ_MAKE_PATH: "mingw32-make"
   FUNQ_CXXFLAGS: "-Wall -Wextra -Werror"  # make CI fail on warnings
+  matrix:
+    # Test with oldest Qt version available on AppVeyor
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
+      QT_DIR: C:/Qt/5.3/mingw482_32
+      MINGW_DIR: C:/Qt/Tools/mingw482_32
+    # Test with latest Qt LTS version
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      QT_DIR: C:/Qt/5.12/mingw73_32
+      MINGW_DIR: C:/Qt/Tools/mingw730_32
+    # Test with latest Qt version available on AppVeyor
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      QT_DIR: C:/Qt/5.14/mingw73_32
+      MINGW_DIR: C:/Qt/Tools/mingw730_32
 
 init:
-  - set PATH=C:/Qt/5.11/mingw53_32/bin;C:/Qt/Tools/mingw530_32/bin;%PATH%
+  - set PATH=%QT_DIR%/bin;%MINGW_DIR%/bin;%PATH%
 
 install:
-  - cp C:/Qt/Tools/mingw530_32/bin/mingw32-make.exe C:/Qt/Tools/mingw530_32/bin/make.exe
   - cd client && python setup.py develop && cd ..
   - cd server && python setup.py develop && cd ..
-  - cd server/tests && qmake QMAKE_CXXFLAGS="%FUNQ_CXXFLAGS%" && make -j4 && cd ../../
-  - cd tests-functionnal/funq-test-app && qmake QMAKE_CXXFLAGS="%FUNQ_CXXFLAGS%" && make -j4 && cd ../..
+  - cd server/tests && qmake QMAKE_CXXFLAGS="%FUNQ_CXXFLAGS%" && mingw32-make -j4 && cd ../../
+  - cd tests-functionnal/funq-test-app && qmake QMAKE_CXXFLAGS="%FUNQ_CXXFLAGS%" && mingw32-make -j4 && cd ../..
 
 build_script:
   - cd client && python setup.py test && cd ..
-  - make -C server/tests/ check
+  - mingw32-make -C server/tests/ check
   - cd tests-functionnal && nosetests && cd ..

--- a/ci/install_dependencies.sh
+++ b/ci/install_dependencies.sh
@@ -22,18 +22,23 @@ then
     PATCH=`echo "$QT_SELECT" | cut -d'.' -f 3`
     PREFIX="" && [[ "$MINOR" -ge 10 ]] && PREFIX="-"
     SEPARATOR="" && [[ "$MINOR" -ge 10 ]] && SEPARATOR="."
-    sudo add-apt-repository "ppa:beineri/opt-qt${PREFIX}${MAJOR}${SEPARATOR}${MINOR}${SEPARATOR}${PATCH}-trusty" -y
+    CODENAME=`lsb_release -sc`
+    sudo add-apt-repository "ppa:beineri/opt-qt${PREFIX}${MAJOR}${SEPARATOR}${MINOR}${SEPARATOR}${PATCH}-$CODENAME" -y
     sudo apt-get update -q
-    sudo apt-get install -q "qt${MAJOR}${MINOR}base" "qt${MAJOR}${MINOR}tools" "qt${MAJOR}${MINOR}declarative"
+    sudo apt-get install -q "qt${MAJOR}${MINOR}base" "qt${MAJOR}${MINOR}tools" "qt${MAJOR}${MINOR}declarative" libglu1-mesa-dev
     source "/opt/qt${MAJOR}${MINOR}/bin/qt${MAJOR}${MINOR}-env.sh"
   fi
 
   # python packages
   pip install flake8
 
-  # xvfb
-  export DISPLAY=:99.0
-  sh -e /etc/init.d/xvfb start
+  # xvfb is only needed on Trusty, see deteils here:
+  # https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-xvfb-to-run-tests-that-require-a-gui
+  if [[ "`lsb_release -sc`" == "trusty" ]]
+  then
+    export DISPLAY=:99.0
+    sh -e /etc/init.d/xvfb start
+  fi
 
 
 # Install dependencies on OS X

--- a/server/libFunq/dragndropresponse.cpp
+++ b/server/libFunq/dragndropresponse.cpp
@@ -152,6 +152,7 @@ void DragNDropResponse::execute(int call) {
                 new QMouseEvent(QEvent::MouseButtonRelease, m_destPos,
                                 m_destPosGlobal, Qt::LeftButton, Qt::NoButton,
                                 Qt::NoModifier));
+            break;
         }
         case 5:  // and reply
             writeResponse(QtJson::JsonObject());

--- a/server/setup.py
+++ b/server/setup.py
@@ -86,17 +86,15 @@ class build_libfunq(Command):
     def run(self):
         if self.force:
             subprocess.call([self.make_path, 'clean'], shell=True)
-        buildtype = 'Debug' if self.debug else 'Release'
-        qmake_cmd = [self.qmake_path, 'CONFIG+=%s' % buildtype, '-r']
+        qmake_cmd = [self.qmake_path, '-r']
         if IS_WINDOWS:
             qmake_cmd += ['-spec', 'win32-g++']
         if self.cxxflags:
             qmake_cmd += ['QMAKE_CXXFLAGS="' + self.cxxflags + '"']
         print('running %s' % qmake_cmd)
         subprocess.check_call(qmake_cmd)
-        make_cmd = [self.make_path]
-        if IS_WINDOWS:
-            make_cmd += ['debug' if self.debug else 'release']
+        buildtype = 'debug' if self.debug else 'release'
+        make_cmd = [self.make_path, buildtype]
         print('running %s' % make_cmd)
         subprocess.check_call(make_cmd, shell=True)
 


### PR DESCRIPTION
With a recent Qt version, building funq-server failed on Windows with following error:

    No rule to make target 'release'

By passing the build type (debug/release) only to the "make" command, but not to the "qmake" command fixes the error. And of course, building with older Qt versions still works.

In addition, I added more CI jobs to also build with the latest Qt versions. This way we can ensure that Funq also works with recent Qt versions.