### PR TITLE
Reduce env matrix and update Qt 5 and Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,10 @@ env:
 matrix:
   fast_finish: true
   include:
+    # MacOS Qt4 Python2
+    - os: osx
+      language: cpp
+      env: QT_SELECT=4 PYTHON=python2
 
     # MacOS Qt5 Python2
     - os: osx
@@ -35,103 +39,26 @@ matrix:
       python: 2.7
       env: QT_SELECT=4 PYTHON=python
 
-    # Linux Qt4 Python3.4
+    # Linux Qt4 Python3.10
     - os: linux
       dist: trusty
       language: python
-      python: 3.4
+      python: 3.10
       env: QT_SELECT=4 PYTHON=python
 
-    # Linux Qt5.2.1 Python2.7
+    # Linux Qt5.15.2 Python2.7
     - os: linux
       dist: trusty
-      language: python
+      language: bionic
       python: 2.7
-      env: QT_SELECT=5.2.1 PYTHON=python
+      env: QT_SELECT=5.15.2 PYTHON=python
 
-    # Linux Qt5.3.2 Python3.4
-    - os: linux
-      dist: trusty
-      language: python
-      python: 3.4
-      env: QT_SELECT=5.3.2 PYTHON=python
-
-    # Linux Qt5.4.2 Python2.7
-    - os: linux
-      dist: trusty
-      language: python
-      python: 2.7
-      env: QT_SELECT=5.4.2 PYTHON=python
-
-    # Linux Qt5.5.1 Python3.4
-    - os: linux
-      dist: trusty
-      language: python
-      python: 3.4
-      env: QT_SELECT=5.5.1 PYTHON=python
-
-    # Linux Qt5.6.3 Python2.7
-    - os: linux
-      dist: trusty
-      language: python
-      python: 2.7
-      env: QT_SELECT=5.6.3 PYTHON=python
-
-    # Linux Qt5.7.1 Python3.4
-    - os: linux
-      dist: trusty
-      language: python
-      python: 3.4
-      env: QT_SELECT=5.7.1 PYTHON=python
-
-    # Linux Qt5.8 Python2.7
-    - os: linux
-      dist: trusty
-      language: python
-      python: 2.7
-      env: QT_SELECT=5.8 PYTHON=python
-
-    # Linux Qt5.9.6 Python3.4
-    - os: linux
-      dist: trusty
-      language: python
-      python: 3.4
-      env: QT_SELECT=5.9.6 PYTHON=python
-
-    # Linux Qt5.10.1 Python2.7
-    - os: linux
-      dist: trusty
-      language: python
-      python: 2.7
-      env: QT_SELECT=5.10.1 PYTHON=python
-
-    # Linux Qt5.11.3 Python2.7
-    - os: linux
-      dist: xenial
-      language: python
-      python: 2.7
-      env: QT_SELECT=5.11.3 PYTHON=python
-
-    # Linux Qt5.12.8 Python3.5
-    - os: linux
-      dist: xenial
-      language: python
-      python: 3.5
-      env: QT_SELECT=5.12.8 PYTHON=python
-
-    # Linux Qt5.13.2 Python2.7
+    # Linux Qt5.15.2 Python3.10
     - os: linux
       dist: bionic
       language: python
-      python: 2.7
-      env: QT_SELECT=5.13.2 PYTHON=python
-
-    # Linux Qt5.14.2 Python3.8
-    - os: linux
-      dist: bionic
-      language: python
-      python: 3.8
-      env: QT_SELECT=5.14.2 PYTHON=python
+      python: 3.10
+      env: QT_SELECT=5.15.2 PYTHON=python
 
 install:
   - source ./ci/install_dependencies.sh # source required because of exports

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,19 +10,20 @@ environment:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
       QT_DIR: C:/Qt/5.3/mingw482_32
       MINGW_DIR: C:/Qt/Tools/mingw482_32
+      PY_DIR: "C:\\Python27"
     # Test with latest Qt 5 LTS version
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       QT_DIR: C:/Qt/5.15/mingw81_32
       MINGW_DIR: C:/Qt/Tools/mingw810_32
-      PYTHON: "C:\\Python310"
+      PY_DIR: "C:\\Python310"
     # Test with latest Qt 5 version available on AppVeyor
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
       QT_DIR: C:/Qt/5.15/mingw81_32
       MINGW_DIR: C:/Qt/Tools/mingw810_32
-      PYTHON: "C:\\Python310"
+      PY_DIR: "C:\\Python310"
 
 init:
-  - set PATH=%QT_DIR%/bin;%MINGW_DIR%/bin;%PATH%
+  - set PATH=%PY_DIR%;%PY_DIR%\Scripts;PATH=%QT_DIR%/bin;%MINGW_DIR%/bin;%PATH%
 
 install:
   - cd client && python setup.py develop && cd ..

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,10 +14,12 @@ environment:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       QT_DIR: C:/Qt/5.15/mingw81_32
       MINGW_DIR: C:/Qt/Tools/mingw810_32
+      PYTHON: "C:\\Python310"
     # Test with latest Qt 5 version available on AppVeyor
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
       QT_DIR: C:/Qt/5.15/mingw81_32
       MINGW_DIR: C:/Qt/Tools/mingw810_32
+      PYTHON: "C:\\Python310"
 
 init:
   - set PATH=%QT_DIR%/bin;%MINGW_DIR%/bin;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,6 +26,9 @@ init:
   - set PATH=%PY_DIR%;%PY_DIR%\Scripts;PATH=%QT_DIR%/bin;%MINGW_DIR%/bin;%PATH%
 
 install:
+  - echo "----- SETUP -----"
+  - python --version
+  - echo "-----------------"
   - cd client && python setup.py develop && cd ..
   - cd server && python setup.py develop && cd ..
   - cd server/tests && qmake QMAKE_CXXFLAGS="%FUNQ_CXXFLAGS%" && mingw32-make -j4 && cd ../../

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,14 +10,14 @@ environment:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
       QT_DIR: C:/Qt/5.3/mingw482_32
       MINGW_DIR: C:/Qt/Tools/mingw482_32
-    # Test with latest Qt LTS version
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      QT_DIR: C:/Qt/5.12/mingw73_32
-      MINGW_DIR: C:/Qt/Tools/mingw730_32
-    # Test with latest Qt version available on AppVeyor
+    # Test with latest Qt 5 LTS version
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-      QT_DIR: C:/Qt/5.14/mingw73_32
-      MINGW_DIR: C:/Qt/Tools/mingw730_32
+      QT_DIR: C:/Qt/5.15/mingw81_32
+      MINGW_DIR: C:/Qt/Tools/mingw810_32
+    # Test with latest Qt 5 version available on AppVeyor
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+      QT_DIR: C:/Qt/5.15/mingw81_32
+      MINGW_DIR: C:/Qt/Tools/mingw810_32
 
 init:
   - set PATH=%QT_DIR%/bin;%MINGW_DIR%/bin;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,9 +26,7 @@ init:
   - set PATH=%PY_DIR%;%PY_DIR%\Scripts;PATH=%QT_DIR%/bin;%MINGW_DIR%/bin;%PATH%
 
 install:
-  - echo "----- SETUP -----"
-  - python --version
-  - echo "-----------------"
+  - python -m pip install --upgrade pip
   - cd client && python setup.py develop && cd ..
   - cd server && python setup.py develop && cd ..
   - cd server/tests && qmake QMAKE_CXXFLAGS="%FUNQ_CXXFLAGS%" && mingw32-make -j4 && cd ../../

--- a/client/setup.py
+++ b/client/setup.py
@@ -29,7 +29,6 @@ setup(
     version=version,
     packages=find_packages(),
     zip_safe=False,
-    use_2to3=True,
     test_suite='funq.tests.create_test_suite',
     install_requires=install_requires,
     package_data={'funq': ['aliases-gkits.conf']},


### PR DESCRIPTION
This PR aims to update the CI and reduce the number of testing versions, for now, we are testing:

- Qt4 with python2 and python3
- Latest LTS Qt5 with python2 and python3

I have plans to support Qt6, but for now, just updating for Qt5

